### PR TITLE
Send peers a secret to validate reconnects.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '^1.18'
+    - run: go version
     - run: yarn
     - run: yarn lint
     - run: yarn cucumber

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -59,7 +59,7 @@ BeforeAll((cb: Function) => {
   ['signaling', 'testproxy'].forEach(backend => {
     const proc = spawn('go', ['build', '-o', `/tmp/netlib-cucumber-${backend}`, `cmd/${backend}/main.go`], {
       windowsHide: true,
-      stdio: 'pipe'
+      stdio: 'inherit'
     })
     proc.on('close', () => {
       if (proc.exitCode !== 0) {

--- a/internal/signaling/timeout_manager.go
+++ b/internal/signaling/timeout_manager.go
@@ -47,7 +47,7 @@ func (i *TimeoutManager) RunOnce(ctx context.Context) {
 		t := tp.time
 		if now.Sub(t) > i.DisconnectThreshold {
 			logger.Debug("peer timed out closing peer", zap.String("id", p.ID))
-			delete(i.peers, p.ID)
+			delete(i.peers, p.ID+p.Secret)
 			go p.Close()
 		}
 	}
@@ -64,7 +64,7 @@ func (i *TimeoutManager) Disconnected(ctx context.Context, p *Peer) {
 	}
 
 	logger.Debug("peer marked as disconnected", zap.String("id", p.ID))
-	i.peers[p.ID] = timedPeer{
+	i.peers[p.ID+p.Secret] = timedPeer{
 		peer: p,
 		time: util.Now(ctx),
 	}
@@ -81,7 +81,8 @@ func (i *TimeoutManager) Reconnected(ctx context.Context, p *Peer) bool {
 	}
 
 	logger.Debug("peer marked as reconnected", zap.String("id", p.ID))
-	_, seen := i.peers[p.ID]
-	delete(i.peers, p.ID)
+	key := p.ID + p.Secret
+	_, seen := i.peers[key]
+	delete(i.peers, key)
 	return seen
 }

--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -10,15 +10,17 @@ import (
 type HelloPacket struct {
 	Type string `json:"type"`
 
-	Game  string `json:"game"`
-	ID    string `json:"id"`
-	Lobby string `json:"lobby"`
+	Game   string `json:"game"`
+	ID     string `json:"id"`
+	Secret string `json:"secret"`
+	Lobby  string `json:"lobby"`
 }
 
 type WelcomePacket struct {
 	Type string `json:"type"`
 
-	ID string `json:"id"`
+	ID     string `json:"id"`
+	Secret string `json:"secret"`
 }
 
 type CreatePacket struct {

--- a/internal/util/identifiers.go
+++ b/internal/util/identifiers.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"context"
+	"encoding/base32"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+
+	crand "crypto/rand"
+
+	"github.com/koenbollen/logging"
+	"github.com/rs/xid"
+	"go.uber.org/zap"
+)
+
+func GeneratePeerID(ctx context.Context) string {
+	if os.Getenv("ENV") == "test" {
+		return strconv.FormatInt(rand.Int63(), 36) // deterministic for testing
+	}
+	return xid.New().String()
+}
+
+func GenerateSecret(ctx context.Context) string {
+	if os.Getenv("ENV") == "test" {
+		return "secret" // deterministic for testing
+	}
+
+	buf := make([]byte, 15)
+	if _, err := crand.Read(buf[:]); err != nil {
+		logger := logging.GetLogger(ctx)
+		logger.Error("error generating secret", zap.Error(err))
+		panic(err)
+	}
+	return strings.ToLower(base32.StdEncoding.EncodeToString(buf))
+}
+
+func GenerateLobbyCode(ctx context.Context) string {
+	return strconv.FormatInt(rand.Int63(), 36)
+}

--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -13,6 +13,7 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
   private reconnectAttempt: number = 0
   private reconnecting: boolean = false
   receivedID?: string
+  receivedSecret?: string
   currentLobby?: string
 
   private readonly connections: Map<string, Peer>
@@ -37,7 +38,8 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
       this.send({
         type: 'hello',
         game: this.network.gameID,
-        id: this.receivedID
+        id: this.receivedID,
+        secret: this.receivedSecret
       })
     }
     const onError = (e: Event): void => {
@@ -127,6 +129,7 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
             throw new Error('missing id on received welcome packet')
           }
           this.receivedID = packet.id
+          this.receivedSecret = packet.secret
           this.network.emit('ready')
           this.network._prefetchTURNCredentials()
           break

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,12 +18,14 @@ export interface HelloPacket extends Base {
   type: 'hello'
   game: string
   id?: string
+  secret?: string
   lobby?: string
 }
 
 export interface WelcomePacket extends Base {
   type: 'welcome'
   id: string
+  secret: string
 }
 
 export interface CreatePacket extends Base {


### PR DESCRIPTION
Currently anyone can reconnect as another peer ID and take over the connection. This PR adds a secret so only the original peer can reconnect.

This change is **not** backwards compatible. Games using an old netlib (after this PR) won't be able to reconnect.