### PR TITLE
Introduce the sort, typable lobby code

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -32,7 +32,7 @@ n.on('ready', () => {
 
   document.querySelector('a[data-action="create"]')?.addEventListener('click', () => {
     if (n.currentLobby === undefined) {
-      void n.create()
+      void n.create({ codeFormat: 'short' })
     }
   })
 

--- a/features/basic.feature
+++ b/features/basic.feature
@@ -16,6 +16,17 @@ Feature: Players can create and connect a network of players
     And "green" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
 
+  Scenario: A player can create a lobby with a short code
+    Given "green" is connected and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
+    When "green" creates a lobby with these settings:
+      """
+      {
+        "codeFormat": "short"
+      }
+      """
+    And "green" receives the network event "lobby" with the argument "34SB"
+
+
   Scenario: Connect two players to a lobby
     Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"

--- a/features/support/steps/network.ts
+++ b/features/support/steps/network.ts
@@ -68,6 +68,15 @@ When('{string} creates a lobby', function (this: World, playerName: string) {
   void player.network.create()
 })
 
+When('{string} creates a lobby with these settings:', function (this: World, playerName: string, settingsBlob: string) {
+  const player = this.players.get(playerName)
+  if (player == null) {
+    return 'no such player'
+  }
+  const settings = JSON.parse(settingsBlob)
+  void player.network.create(settings)
+})
+
 When('{string} connects to the lobby {string}', function (this: World, playerName: string, lobbyCode: string) {
   const player = this.players.get(playerName)
   if (player == null) {

--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -42,6 +42,7 @@ type CreatePacket struct {
 	RequestID string `json:"rid"`
 	Type      string `json:"type"`
 
+	CodeFormat string         `json:"codeFormat"`
 	Public     bool           `json:"public"`
 	Password   string         `json:"password"`
 	MaxPlayers int            `json:"maxPlayers"`

--- a/internal/util/identifiers.go
+++ b/internal/util/identifiers.go
@@ -39,3 +39,9 @@ func GenerateSecret(ctx context.Context) string {
 func GenerateLobbyCode(ctx context.Context) string {
 	return strconv.FormatInt(rand.Int63(), 36)
 }
+
+func GenerateShortLobbyCode(ctx context.Context) string {
+	numbers := []string{"2", "3", "4", "5", "6", "7", "8", "9"}
+	alphabet := []string{"A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "M", "N", "P", "R", "S", "T", "V", "W", "X", "Y", "Z"}
+	return numbers[rand.Intn(len(numbers))] + numbers[rand.Intn(len(numbers))] + alphabet[rand.Intn(len(alphabet))] + alphabet[rand.Intn(len(alphabet))]
+}

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -65,7 +65,7 @@ export default class Network extends EventEmitter<NetworkListeners> {
     }
     const reply = await this.signaling.request({
       type: 'create',
-      settings
+      ...settings
     })
     if (reply.type === 'joined') {
       return reply.lobby

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,10 +4,12 @@ export interface PeerConfiguration extends RTCConfiguration {
 }
 
 export interface LobbySettings {
-  maxPlayers: number
+  codeFormat?: 'default' | 'short'
+  codeLength?: number
+  maxPlayers?: number
   password?: string
-  public: boolean
-  customData: {[key: string]: any}
+  public?: boolean
+  customData?: {[key: string]: any}
 }
 
 export interface LobbyListEntry extends LobbySettings{


### PR DESCRIPTION
Some games want the lobby code to be short so they can be copied verbally and typed in.

This change introduce the codeFormat setting to pick the short lobby code.

Also fixed settings in the create packet.