### PR TITLE
HOTFIX NoRows is not an error.

### DIFF
--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -337,7 +337,10 @@ func (s *PostgresStore) ClaimNextTimedOutPeer(ctx context.Context, threshold tim
 	`, now.Add(-threshold)).Scan(&peerID, &gameID, &lobbies)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return false, tx.Commit(ctx)
+			if err := tx.Commit(ctx); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+				return false, err
+			}
+			return false, nil
 		}
 		return false, err
 	}

--- a/internal/signaling/timeout_manager.go
+++ b/internal/signaling/timeout_manager.go
@@ -79,6 +79,10 @@ func (i *TimeoutManager) disconnectPeerInLobby(ctx context.Context, peerID strin
 func (i *TimeoutManager) Disconnected(ctx context.Context, p *Peer) {
 	logger := logging.GetLogger(ctx)
 
+	if p.ID == "" {
+		return
+	}
+
 	logger.Debug("peer marked as disconnected", zap.String("id", p.ID))
 	err := i.Store.TimeoutPeer(ctx, p.ID, p.Secret, p.Game, []string{p.Lobby})
 	if err != nil {


### PR DESCRIPTION
Also I found while testing, the timeout manager should not timeout if the peer has no ID yet.