### PR TITLE
Better handle closing of clients

### DIFF
--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -77,7 +77,7 @@ type DisconnectPacket struct {
 	Reason string `json:"reason"`
 }
 
-type LeavePacket struct {
+type ClosePacket struct {
 	Type string `json:"type"`
 
 	ID     string `json:"id"`

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -92,7 +92,7 @@ export default class Network extends EventEmitter<NetworkListeners> {
 
     if (this.id !== '') {
       this.signaling.send({
-        type: 'leave',
+        type: 'close',
         id: this.id,
         reason: reason ?? 'normal closure'
       })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,6 +27,7 @@ interface Base {
 
 export type SignalingPacketTypes =
 | CandidatePacket
+| ClosePacket
 | ConnectedPacket
 | ConnectPacket
 | CreatePacket
@@ -39,7 +40,6 @@ export type SignalingPacketTypes =
 | HelloPacket
 | JoinedPacket
 | JoinPacket
-| LeavePacket
 | ListPacket
 | LobbiesPacket
 | WelcomePacket
@@ -91,8 +91,8 @@ export interface JoinedPacket extends Base {
   id: string
 }
 
-export interface LeavePacket extends Base {
-  type: 'leave'
+export interface ClosePacket extends Base {
+  type: 'close'
   id: string
   reason: string
 }


### PR DESCRIPTION
There was a 'leave' packet that was interpreted differently by the client and server and we corrected this.
Also don't accept any messages anymore after a close message is received.
And when a client closes we don't add them to the timeout manager when the connection is broken.

(leaving of lobbies, as the leave packet was interpreted by the server was never a feature, soon™)