### PR TITLE
Make the closing of connection backwards compatible.

### DIFF
--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -123,6 +123,8 @@ func (p *Peer) HandlePacket(ctx context.Context, typ string, raw []byte) error {
 			return fmt.Errorf("unable to handle packet: %w", err)
 		}
 
+	case "leave": // legacy, backwards compatibility
+		fallthrough
 	case "close":
 		packet := ClosePacket{}
 		if err := json.Unmarshal(raw, &packet); err != nil {


### PR DESCRIPTION
We forgot for a second that we need to be backwards compatible. 🙈 Luckly this was only on closing the connection/client so gameplay wasn't affected.