### PR TITLE
Add len checks for lobby and peer ids

### DIFF
--- a/internal/signaling/stores/shared.go
+++ b/internal/signaling/stores/shared.go
@@ -10,6 +10,8 @@ var ErrAlreadyInLobby = errors.New("peer already in lobby")
 var ErrLobbyExists = errors.New("lobby already exists")
 var ErrNotFound = errors.New("lobby not found")
 var ErrNoSuchTopic = errors.New("no such topic")
+var ErrInvalidLobbyCode = errors.New("invalid lobby code")
+var ErrInvalidPeerID = errors.New("invalid peer id")
 
 type SubscriptionCallback func(context.Context, []byte)
 


### PR DESCRIPTION
We are getting some weird errors in our database that are exceeding the type length. This should help us learn more about the issue.