### PR TITLE
Rejoin peers into lobbies based on timeoutmanager

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -60,7 +60,7 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 			retrievedIDCallback: manager.Reconnected,
 		}
 		defer func() {
-			logger.Info("peer websocket closed", zap.String("peer", peer.ID))
+			logger.Info("peer websocket closed", zap.String("peer", peer.ID), zap.String("game", peer.Game), zap.String("origin", r.Header.Get("Origin")))
 			conn.Close(websocket.StatusInternalError, "unexpceted closure")
 
 			if !peer.closedPacketReceived {

--- a/internal/signaling/stores/shared.go
+++ b/internal/signaling/stores/shared.go
@@ -27,7 +27,7 @@ type Store interface {
 	Publish(ctx context.Context, topic string, data []byte) error
 
 	TimeoutPeer(ctx context.Context, peerID, secret, gameID string, lobbies []string) error
-	ReconnectPeer(ctx context.Context, peerID, secret, gameID string) (bool, error)
+	ReconnectPeer(ctx context.Context, peerID, secret, gameID string) (bool, []string, error)
 	ClaimNextTimedOutPeer(ctx context.Context, threshold time.Duration, callback func(peerID, gameID string, lobbies []string) error) (bool, error)
 }
 

--- a/internal/signaling/timeout_manager.go
+++ b/internal/signaling/timeout_manager.go
@@ -83,14 +83,18 @@ func (i *TimeoutManager) Disconnected(ctx context.Context, p *Peer) {
 		return
 	}
 
-	logger.Debug("peer marked as disconnected", zap.String("id", p.ID))
-	err := i.Store.TimeoutPeer(ctx, p.ID, p.Secret, p.Game, []string{p.Lobby})
+	logger.Debug("peer marked as disconnected", zap.String("id", p.ID), zap.String("lobby", p.Lobby))
+	lobbies := []string{}
+	if p.Lobby != "" {
+		lobbies = []string{p.Lobby}
+	}
+	err := i.Store.TimeoutPeer(ctx, p.ID, p.Secret, p.Game, lobbies)
 	if err != nil {
 		logger.Error("failed to record timeout peer", zap.Error(err))
 	}
 }
 
-func (i *TimeoutManager) Reconnected(ctx context.Context, p *Peer) (bool, error) {
+func (i *TimeoutManager) Reconnected(ctx context.Context, p *Peer) (bool, []string, error) {
 	logger := logging.GetLogger(ctx)
 
 	logger.Debug("peer marked as reconnected", zap.String("id", p.ID))

--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -18,7 +18,6 @@ type HelloPacket struct {
 	Game   string `json:"game"`
 	ID     string `json:"id"`
 	Secret string `json:"secret"`
-	Lobby  string `json:"lobby"`
 }
 
 type WelcomePacket struct {

--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -41,8 +41,7 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
         type: 'hello',
         game: this.network.gameID,
         id: this.receivedID,
-        secret: this.receivedSecret,
-        lobby: this.currentLobby
+        secret: this.receivedSecret
       })
     }
     const onError = (e: Event): void => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,7 +61,6 @@ export interface HelloPacket extends Base {
   game: string
   id?: string
   secret?: string
-  lobby?: string
 }
 
 export interface WelcomePacket extends Base {


### PR DESCRIPTION
This changes the rejoining logic. Before the lobby a peer got rejoined to was reported by the client. Now this lobby is returned by the timeout state in the database.

We are making improvements on the reconnecting and on how timed-out peers are handled in order to create a clean lobby list in the database. This is required for implementing features like lobby filtering (for #48 and #49).