### PR TITLE
Set public setting when creating lobby.

### DIFF
--- a/features/lobbies.feature
+++ b/features/lobbies.feature
@@ -55,8 +55,8 @@ Feature: Lobby Discovery
 
     When "green" requests all lobbies
     Then "green" should have received only these lobbies
-      | code         | playerCount |
-      | dhgp75mn2bll | 1           |
+      | code         | playerCount | public |
+      | dhgp75mn2bll | 1           | true   |
 
 
 

--- a/features/lobbies.feature
+++ b/features/lobbies.feature
@@ -20,13 +20,43 @@ Feature: Lobby Discovery
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
-    When "blue" creates a lobby
+    When "blue" creates a lobby with these settings:
+      """
+      {
+        "public": true
+      }
+      """
     And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
 
     When "green" requests all lobbies
     Then "green" should have received only these lobbies
       | code         | playerCount |
       | prb67ouj837u | 1           |
+
+  Scenario: Only list public lobbies
+    Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "yellow" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+
+    When "blue" creates a lobby with these settings:
+      """
+      {
+        "public": true
+      }
+      """
+    And "blue" receives the network event "lobby" with the argument "dhgp75mn2bll"
+    And "yellow" creates a lobby with these settings:
+      """
+      {
+        "public": false
+      }
+      """
+    And "yellow" receives the network event "lobby" with the argument "1qva9vyurwbbl"
+
+    When "green" requests all lobbies
+    Then "green" should have received only these lobbies
+      | code         | playerCount |
+      | dhgp75mn2bll | 1           |
 
 
 

--- a/features/support/steps/network.ts
+++ b/features/support/steps/network.ts
@@ -1,5 +1,4 @@
 import { After, DataTable, Given, Then, When } from '@cucumber/cucumber'
-import assert from 'assert'
 import { World } from '../world'
 
 After(async function (this: World) {
@@ -178,7 +177,12 @@ Then('{string} should have received only these lobbies', function (this: World, 
         delete lobby[key]
       }
     })
-    assert.notStrictEqual(lobby, row)
+    const want = row as any
+    Object.keys(row).forEach(key => {
+      if (`${lobby[key] as string}` !== `${want[key] as string}`) {
+        throw new Error(`expected ${key} to be ${want[key] as string} but got ${lobby[key] as string}`)
+      }
+    })
   })
   if (player.lastReceivedLobbies.length !== expectedLobbies.hashes().length) {
     throw new Error(`expected ${expectedLobbies.hashes().length} lobbies but got ${player.lastReceivedLobbies.length}`)

--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -336,7 +336,7 @@ func (p *Peer) HandleCreatePacket(ctx context.Context, packet CreatePacket) erro
 			p.Lobby = util.GenerateLobbyCode(ctx)
 		}
 
-		err := p.store.CreateLobby(ctx, p.Game, p.Lobby, p.ID)
+		err := p.store.CreateLobby(ctx, p.Game, p.Lobby, p.ID, packet.Public)
 		if err != nil {
 			if err == stores.ErrLobbyExists {
 				continue

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -279,7 +279,7 @@ func (s *PostgresStore) ListLobbies(ctx context.Context, game, filter string) ([
 
 	var lobbies []Lobby
 	rows, err := s.DB.Query(ctx, `
-		SELECT code, peers, meta
+		SELECT code, peers, public, meta
 		FROM lobbies
 		WHERE game = $1
 		AND public = true
@@ -294,7 +294,7 @@ func (s *PostgresStore) ListLobbies(ctx context.Context, game, filter string) ([
 	for rows.Next() {
 		var lobby Lobby
 		var peers []string
-		err = rows.Scan(&lobby.Code, &peers, &lobby.CustomData)
+		err = rows.Scan(&lobby.Code, &peers, &lobby.Public, &lobby.CustomData)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -140,7 +140,7 @@ func (s *PostgresStore) Publish(ctx context.Context, topic string, data []byte) 
 	return nil
 }
 
-func (s *PostgresStore) CreateLobby(ctx context.Context, game, lobbyCode, peerID string) error {
+func (s *PostgresStore) CreateLobby(ctx context.Context, game, lobbyCode, peerID string, public bool) error {
 	if len(lobbyCode) > 20 {
 		logger := logging.GetLogger(ctx)
 		logger.Warn("lobby code too long", zap.String("lobbyCode", lobbyCode))
@@ -154,9 +154,9 @@ func (s *PostgresStore) CreateLobby(ctx context.Context, game, lobbyCode, peerID
 	now := util.Now(ctx)
 	res, err := s.DB.Exec(ctx, `
 		INSERT INTO lobbies (code, game, public, created_at, updated_at)
-		VALUES ($1, $2, true, $3, $3)
+		VALUES ($1, $2, $3, $4, $4)
 		ON CONFLICT DO NOTHING
-	`, lobbyCode, game, now)
+	`, lobbyCode, game, public, now)
 	if err != nil {
 		return err
 	}

--- a/internal/signaling/stores/shared.go
+++ b/internal/signaling/stores/shared.go
@@ -16,7 +16,7 @@ var ErrInvalidPeerID = errors.New("invalid peer id")
 type SubscriptionCallback func(context.Context, []byte)
 
 type Store interface {
-	CreateLobby(ctx context.Context, game, lobby, id string) error
+	CreateLobby(ctx context.Context, game, lobby, id string, public bool) error
 	JoinLobby(ctx context.Context, game, lobby, id string) ([]string, error)
 	IsPeerInLobby(ctx context.Context, game, lobby, id string) (bool, error)
 	LeaveLobby(ctx context.Context, game, lobby, id string) ([]string, error)


### PR DESCRIPTION
Previously the `public` setting was ignored by the backend and never saved in the database, thus all lobbies where public and listing lobbies would return everything.

This change actually stored the public setting in the database, the filter for public-only lobbies in listing was already in place.

This is a backwards-incompatible change, but no live games we know of use this feature at the moment.

Fixes #49