### PR TITLE
Listing no lobbies should return an empty array.

### DIFF
--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -311,6 +311,9 @@ func (p *Peer) HandleListPacket(ctx context.Context, packet ListPacket) error {
 	if err != nil {
 		return err
 	}
+	if lobbies == nil {
+		lobbies = []stores.Lobby{}
+	}
 	return p.Send(ctx, LobbiesPacket{
 		RequestID: packet.RequestID,
 		Type:      "lobbies",


### PR DESCRIPTION
When no lobbies are available for a game when listing lobbies the API used to return `null`, this change makes that an empty array instead `[]`.


Fixes #68