### PR TITLE
Fix credentials not being returned along with the request ID

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -120,9 +120,16 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 				if err != nil {
 					util.ReplyError(ctx, conn, err)
 				} else {
+					requestPacket := CredentialsPacket{}
+					if err := json.Unmarshal(raw, &requestPacket); err != nil {
+						util.ReplyError(ctx, conn, err)
+						continue
+					}
+
 					packet := CredentialsPacket{
 						Type:        "credentials",
 						Credentials: *credentials,
+						RequestID:   requestPacket.RequestID,
 					}
 					if err := peer.Send(ctx, packet); err != nil {
 						util.ErrorAndDisconnect(ctx, conn, err)

--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -97,7 +97,7 @@ type ForwardablePacket struct {
 type CredentialsPacket struct {
 	cloudflare.Credentials
 	Type      string `json:"type"`
-	RequestID string `json:"rid"`
+	RequestID string `json:"rid,omitempty"`
 }
 
 type EventPacket struct {

--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -96,7 +96,8 @@ type ForwardablePacket struct {
 
 type CredentialsPacket struct {
 	cloudflare.Credentials
-	Type string `json:"type"`
+	Type      string `json:"type"`
+	RequestID string `json:"rid"`
 }
 
 type EventPacket struct {


### PR DESCRIPTION
Client expects credentials to be returned as a promise, but it can't match the response to the request due to response ID not being set:

```typescript
if (packet.rid !== undefined) { // this is always false
        const request = this.requests.get(packet.rid)
        if (request != null) {
          this.requests.delete(packet.rid)
          if (packet.type === 'error') {
            request.reject(new SignalingError('server-error', packet.message))
          } else {
            request.resolve(packet)
          }
        }
      }
```

This causes TURN to be completely broken since no credentials are available.

Tested locally by hardcoding some creds:

```go
func (c *CredentialsClient) GetCredentials(ctx context.Context) (*Credentials, error) {
	return &Credentials{
		URL:        "someURL",
		Username:   "bsusername",
		Credential: "bspassword",
		Lifetime:   123,
	}, nil
}
```

Happy to make adjustments as I have no experience in Go :) 