### PR TITLE
Return correct error when lobby already exists

### DIFF
--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -162,7 +162,7 @@ func (s *PostgresStore) CreateLobby(ctx context.Context, game, lobbyCode, peerID
 		return err
 	}
 	if res.RowsAffected() == 0 {
-		return ErrAlreadyInLobby
+		return ErrLobbyExists
 	}
 	return nil
 }


### PR DESCRIPTION
Thanks to @Pedr0Rocha for spotting this.