### PR TITLE
Fix error on listing empty lobbies

### DIFF
--- a/features/lobbies.feature
+++ b/features/lobbies.feature
@@ -105,3 +105,24 @@ Feature: Lobby Discovery
     Then "green" should have received only these lobbies:
       | code          |
       | 2qva9vyurwbbl |
+
+  Scenario: List empty lobbies
+    Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+
+    When "blue" creates a lobby with these settings:
+      """json
+      {
+        "codeFormat": "short",
+        "public": true
+      }
+      """
+    And "blue" receives the network event "lobby" with the argument "52YS"
+
+    When "blue" disconnects
+    Then "blue" receives the network event "close"
+
+    When "green" requests all lobbies
+    Then "green" should have received only these lobbies:
+      | code | playerCount |
+      | 52YS | 0           |

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -292,7 +292,7 @@ func (s *PostgresStore) ListLobbies(ctx context.Context, game, filter string) ([
 		WITH lobbies AS (
 			SELECT
 				code,
-				ARRAY_LENGTH(peers, 1) AS "playerCount",
+				COALESCE(ARRAY_LENGTH(peers, 1), 0) AS "playerCount",
 				public,
 				meta,
 				created_at AS "createdAt",


### PR DESCRIPTION
ARRAY_LENGTH returns NULL instead of 0 for an empty lobby which then can't be scanned into an int.

Fixes https://github.com/poki/netlib/issues/82