### PR TITLE
Return lobby information when joining a lobby

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -24,8 +24,11 @@
   <input id="input" autocomplete="off">
   <ul id="peers">
   </ul>
+
+  filter map: <input id="mapName">
   <ul id="lobbies">
   </ul>
+
   <a href="javascript:void(0)" data-action="create">create lobby</a>
   <a href="javascript:void(0)" data-action="join">join custom lobby</a>
   <script src="./main.ts" type="module"></script>

--- a/features/custom-data.feature
+++ b/features/custom-data.feature
@@ -1,0 +1,61 @@
+Feature: customData on lobbies can be used for filtering and extra information
+
+  Background:
+    Given the "signaling" backend is running
+
+
+  Scenario: Connect to a lobby with custom data
+    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+
+    When "blue" creates a lobby with these settings:
+      """json
+      {
+        "public": true,
+        "customData": {
+          "gameMode": "deathmatch",
+          "map": "de_dust2"
+        }
+      }
+      """
+    Then "blue" receives the network event "lobby" with the arguments:
+      """json
+      [
+        "prb67ouj837u",
+        {
+          "code": "prb67ouj837u",
+          "peers": [
+            "h5yzwyizlwao"
+          ],
+          "playerCount": 1,
+          "public": true,
+          "maxPlayers": 0,
+          "customData": {
+            "gameMode": "deathmatch",
+            "map": "de_dust2"
+          }
+        }
+      ]
+      """
+
+    When "yellow" connects to the lobby "prb67ouj837u"
+    Then "yellow" receives the network event "lobby" with the arguments:
+      """json
+      [
+        "prb67ouj837u",
+        {
+          "code": "prb67ouj837u",
+          "peers": [
+            "3t3cfgcqup9e",
+            "h5yzwyizlwao"
+          ],
+          "playerCount": 2,
+          "public": true,
+          "maxPlayers": 0,
+          "customData": {
+            "gameMode": "deathmatch",
+            "map": "de_dust2"
+          }
+        }
+      ]
+      """

--- a/features/lobbies.feature
+++ b/features/lobbies.feature
@@ -127,13 +127,13 @@ Feature: Lobby Discovery
       | code | playerCount |
       | 52YS | 0           |
 
-  Scenario: Filter lobbies on customData
+  Scenario: Filter created lobbies on customData
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     And these lobbies exist:
       | code         | game                                 | playerCount | public | meta               |
-      | 1qva9vyurwbb | 54fa57d5-b4bd-401d-981d-2c13de99be27 | 9           | true   | {"map": "de_nuke"} |
+      | 1qva9vyurwbb | 54fa57d5-b4bd-401d-981d-2c13de99be27 | 9           | true   | {"map": "de_nuke"} | # different game
       | 2qva9vyurwbb | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 10          | true   | {"map": "de_dust"} |
       | 3qva9vyurwbb | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 10          | true   | {"map": "de_nuke"} |
 

--- a/features/support/steps/network.ts
+++ b/features/support/steps/network.ts
@@ -155,7 +155,7 @@ When('{string} requests lobbies with this filter:', async function (this: World,
   if (player == null) {
     return 'no such player'
   }
-  const lobbies = await player.network.list(filter)
+  const lobbies = await player.network.list(JSON.parse(filter))
   player.lastReceivedLobbies = lobbies
 })
 
@@ -189,6 +189,17 @@ Then('{string} receives the network event {string} with the arguments {string}, 
   const event = await player.waitForEvent(eventName, [expectedArgument0, expectedArgument1, expectedArgument2])
   if (event == null) {
     throw new Error(`no event ${eventName}(${expectedArgument0}, ${expectedArgument1}, ${expectedArgument2}) received`)
+  }
+})
+
+Then('{string} receives the network event {string} with the arguments:', async function (this: World, playerName: string, eventName: string, args: string) {
+  const player = this.players.get(playerName)
+  if (player == null) {
+    throw new Error('no such player')
+  }
+  const event = await player.waitForEvent(eventName, JSON.parse(args))
+  if (event == null) {
+    throw new Error(`no event ${eventName}(...) received`)
   }
 })
 

--- a/features/support/types.ts
+++ b/features/support/types.ts
@@ -58,7 +58,7 @@ export class Player {
         let interval: NodeJS.Timeout | null = null
         const timeout = setTimeout(() => {
           const sameEvents = this.events.slice(this.scanIndex).filter(e => e.eventName === eventName)
-          const others = sameEvents.map(e => Array.from(e.eventPayload).map(a => `${a as string}`).join(',')).join(' + ')
+          const others = sameEvents.map(e => Array.from(e.eventPayload).map(a => `${JSON.stringify(a)}`).join(',')).join(' + ')
           if (interval !== null) {
             clearInterval(interval)
           }
@@ -88,6 +88,13 @@ function matchEvent (e: RecordedEvent, eventName: string, matchArguments: any[] 
     if (typeof arg === 'string' || arg instanceof String) {
       // Fool typescript into calling toString() on the event argument:
       argumentsMatch = `${e.eventPayload[i] as string}` === arg
+    } else if (e.eventPayload[i] instanceof Object) {
+      const a = { ...e.eventPayload[i] }
+      delete a.createdAt
+      delete a.updatedAt
+      delete arg.createdAt
+      delete arg.updatedAt
+      argumentsMatch = JSON.stringify(a) === JSON.stringify(arg)
     } else {
       argumentsMatch = e.eventPayload[i] === arg
     }

--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -364,6 +364,7 @@ func (p *Peer) HandleCreatePacket(ctx context.Context, packet CreatePacket) erro
 		RequestID: packet.RequestID,
 		Type:      "joined",
 		Lobby:     p.Lobby,
+		LobbyCode: p.Lobby,
 	})
 }
 
@@ -387,6 +388,11 @@ func (p *Peer) HandleJoinPacket(ctx context.Context, packet JoinPacket) error {
 		return err
 	}
 
+	lobby, err := p.store.GetLobby(ctx, p.Game, packet.Lobby)
+	if err != nil && err != stores.ErrNotFound {
+		return err
+	}
+
 	p.Lobby = packet.Lobby
 	p.store.Subscribe(ctx, p.Game+p.Lobby+p.ID, p.ForwardMessage)
 
@@ -394,6 +400,8 @@ func (p *Peer) HandleJoinPacket(ctx context.Context, packet JoinPacket) error {
 		RequestID: packet.RequestID,
 		Type:      "joined",
 		Lobby:     p.Lobby,
+		LobbyCode: p.Lobby,
+		LobbyInfo: lobby,
 	})
 	if err != nil {
 		return err

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -271,10 +272,11 @@ func (s *PostgresStore) GetLobby(ctx context.Context, game, lobbyCode string) (L
 		FROM lobbies
 		WHERE code = $1
 		AND game = $2
-	`, lobbyCode, game).Scan(&lobby.Code, &lobby.peers, &lobby.PlayerCount, &lobby.Public, &lobby.CustomData, &lobby.CreatedAt, &lobby.UpdatedAt)
+	`, lobbyCode, game).Scan(&lobby.Code, &lobby.Peers, &lobby.PlayerCount, &lobby.Public, &lobby.CustomData, &lobby.CreatedAt, &lobby.UpdatedAt)
 	if err != nil {
 		return Lobby{}, err
 	}
+	sort.Strings(lobby.Peers)
 	return lobby, nil
 }
 

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -257,21 +257,25 @@ func (s *PostgresStore) LeaveLobby(ctx context.Context, game, lobbyCode, peerID 
 	return peerlist, nil
 }
 
-func (s *PostgresStore) GetLobby(ctx context.Context, game, lobbyCode string) ([]string, error) {
-	var peerlist []string
+func (s *PostgresStore) GetLobby(ctx context.Context, game, lobbyCode string) (Lobby, error) {
+	var lobby Lobby
 	err := s.DB.QueryRow(ctx, `
-		SELECT peers
+		SELECT
+			code,
+			peers,
+			COALESCE(ARRAY_LENGTH(peers, 1), 0) AS "playerCount",
+			public,
+			meta,
+			created_at AS "createdAt",
+			updated_at AS "updatedAt"
 		FROM lobbies
 		WHERE code = $1
 		AND game = $2
-	`, lobbyCode, game).Scan(&peerlist)
+	`, lobbyCode, game).Scan(&lobby.Code, &lobby.peers, &lobby.PlayerCount, &lobby.Public, &lobby.CustomData, &lobby.CreatedAt, &lobby.UpdatedAt)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, err
+		return Lobby{}, err
 	}
-	return peerlist, nil
+	return lobby, nil
 }
 
 func (s *PostgresStore) ListLobbies(ctx context.Context, game, filter string) ([]Lobby, error) {

--- a/internal/signaling/stores/shared.go
+++ b/internal/signaling/stores/shared.go
@@ -34,35 +34,15 @@ type Store interface {
 }
 
 type Lobby struct {
-	Code        string `json:"code"`
-	PlayerCount int    `json:"playerCount"`
+	Code        string   `json:"code"`
+	Peers       []string `json:"peers"`
+	PlayerCount int      `json:"playerCount"`
 
 	Public     bool           `json:"public"`
 	MaxPlayers int            `json:"maxPlayers"`
-	Password   string         `json:"password"`
+	Password   string         `json:"password,omitempty"`
 	CustomData map[string]any `json:"customData"`
 
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
-
-	peers map[string]struct{}
-}
-
-func (l *Lobby) Build() Lobby {
-	clone := Lobby{
-		Code:        l.Code,
-		PlayerCount: len(l.peers),
-		Public:      l.Public,
-		MaxPlayers:  l.MaxPlayers,
-		Password:    l.Password,
-		CustomData:  l.CustomData,
-		peers:       make(map[string]struct{}),
-	}
-	for k, v := range l.CustomData {
-		clone.CustomData[k] = v
-	}
-	for id := range l.peers {
-		clone.peers[id] = struct{}{}
-	}
-	return clone
 }

--- a/internal/signaling/stores/shared.go
+++ b/internal/signaling/stores/shared.go
@@ -20,7 +20,7 @@ type Store interface {
 	JoinLobby(ctx context.Context, game, lobby, id string) ([]string, error)
 	IsPeerInLobby(ctx context.Context, game, lobby, id string) (bool, error)
 	LeaveLobby(ctx context.Context, game, lobby, id string) ([]string, error)
-	GetLobby(ctx context.Context, game, lobby string) ([]string, error)
+	GetLobby(ctx context.Context, game, lobby string) (Lobby, error)
 	ListLobbies(ctx context.Context, game, filter string) ([]Lobby, error)
 
 	Subscribe(ctx context.Context, topic string, callback SubscriptionCallback)

--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -63,7 +63,9 @@ type JoinedPacket struct {
 	RequestID string `json:"rid"`
 	Type      string `json:"type"`
 
-	Lobby string `json:"lobby"`
+	Lobby     string       `json:"lobby"` // for backwards compatibility, can't rename
+	LobbyCode string       `json:"code"`
+	LobbyInfo stores.Lobby `json:"lobbyInfo"`
 }
 
 type ConnectPacket struct {

--- a/internal/signaling/types.go
+++ b/internal/signaling/types.go
@@ -63,8 +63,7 @@ type JoinedPacket struct {
 	RequestID string `json:"rid"`
 	Type      string `json:"type"`
 
-	Lobby     string       `json:"lobby"` // for backwards compatibility, can't rename
-	LobbyCode string       `json:"code"`
+	LobbyCode string       `json:"lobby"` // for backwards compatibility, can't rename
 	LobbyInfo stores.Lobby `json:"lobbyInfo"`
 }
 

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -8,7 +8,7 @@ import Credentials from './credentials'
 
 interface NetworkListeners {
   ready: () => void | Promise<void>
-  lobby: (code: string) => void | Promise<void>
+  lobby: (code: string, lobbyInfo: LobbyListEntry) => void | Promise<void>
   connecting: (peer: Peer) => void | Promise<void>
   connected: (peer: Peer) => void | Promise<void>
   reconnecting: (peer: Peer) => void | Promise<void>
@@ -45,13 +45,14 @@ export default class Network extends EventEmitter<NetworkListeners> {
     }
   }
 
-  async list (filter?: string): Promise<LobbyListEntry[]> {
+  async list (filter?: object): Promise<LobbyListEntry[]> {
     if (this._closing || this.signaling.receivedID === undefined) {
       return []
     }
+    const filterString = (filter != null) ? JSON.stringify(filter) : undefined
     const reply = await this.signaling.request({
       type: 'list',
-      filter
+      filter: filterString
     })
     if (reply.type === 'lobbies') {
       return reply.lobbies
@@ -68,7 +69,7 @@ export default class Network extends EventEmitter<NetworkListeners> {
       ...settings
     })
     if (reply.type === 'joined') {
-      return reply.code
+      return reply.lobbyInfo.code
     }
     return ''
   }
@@ -82,9 +83,9 @@ export default class Network extends EventEmitter<NetworkListeners> {
       lobby
     })
     if (reply.type === 'joined') {
-      return reply.lobbyInfo;
+      return reply.lobbyInfo
     }
-    return undefined;
+    return undefined
   }
 
   close (reason?: string): void {

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -68,19 +68,23 @@ export default class Network extends EventEmitter<NetworkListeners> {
       ...settings
     })
     if (reply.type === 'joined') {
-      return reply.lobby
+      return reply.code
     }
     return ''
   }
 
-  async join (lobby: string): Promise<void> {
+  async join (lobby: string): Promise<LobbyListEntry|undefined> {
     if (this._closing || this.signaling.receivedID === undefined) {
-      return
+      return undefined
     }
-    await this.signaling.request({
+    const reply = await this.signaling.request({
       type: 'join',
       lobby
     })
+    if (reply.type === 'joined') {
+      return reply.lobbyInfo;
+    }
+    return undefined;
   }
 
   close (reason?: string): void {

--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -175,8 +175,8 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
           if (packet.lobby === '') {
             throw new Error('missing lobby on received connect packet')
           }
-          this.currentLobby = packet.lobby
-          this.network.emit('lobby', packet.lobby)
+          this.currentLobby = packet.code
+          this.network.emit('lobby', packet.code)
           break
 
         case 'connect':

--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -172,11 +172,14 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
           break
 
         case 'joined':
-          if (packet.lobby === '') {
-            throw new Error('missing lobby on received connect packet')
+          {
+            const code = packet.lobbyInfo.code
+            if (code === '') {
+              throw new Error('missing lobby on received connect packet')
+            }
+            this.currentLobby = code
+            this.network.emit('lobby', code, packet.lobbyInfo)
           }
-          this.currentLobby = packet.code
-          this.network.emit('lobby', packet.code)
           break
 
         case 'connect':

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,9 +15,10 @@ export interface LobbySettings {
   customData?: {[key: string]: any}
 }
 
-export interface LobbyListEntry extends LobbySettings{
+export interface LobbyListEntry {
   code: string
   playerCount: number
+  customData?: {[key: string]: any}
   createdAt: string
   updatedAt: string
 }
@@ -93,8 +94,9 @@ export interface JoinPacket extends Base {
 
 export interface JoinedPacket extends Base {
   type: 'joined'
-  lobby: string
-  id: string
+  code: string // lobby code
+  lobby: string // lobby code
+  lobbyInfo?: LobbyListEntry
 }
 
 export interface ClosePacket extends Base {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,7 @@ export interface LobbySettings {
 
 export interface LobbyListEntry {
   code: string
+  public: boolean
   playerCount: number
   customData?: {[key: string]: any}
   createdAt: string
@@ -94,9 +95,7 @@ export interface JoinPacket extends Base {
 
 export interface JoinedPacket extends Base {
   type: 'joined'
-  code: string // lobby code
-  lobby: string // lobby code
-  lobbyInfo?: LobbyListEntry
+  lobbyInfo: LobbyListEntry
 }
 
 export interface ClosePacket extends Base {


### PR DESCRIPTION
The argument to `Network.list` is now an object instead of a string. `Network.join` now resolves to an object containing information about the lobby.