### PR TITLE
Fix reconnect loop when reconnecting with bad secret

### DIFF
--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -218,9 +218,13 @@ func (p *Peer) HandleHelloPacket(ctx context.Context, packet HelloPacket) error 
 		if !hasReconnected {
 			logger.Info("peer failed reconnecting", zap.String("game", p.Game), zap.String("peer", p.ID))
 
-			// Return nil immediately. The peer will stay connected, but will not be able to do anything.
+			err := fmt.Errorf("failed to reconnect, missing pid or invalid secret")
+			err = util.ErrorWithCode(err, "reconnect-failed")
+			util.ReplyError(ctx, p.conn, err)
+
+			// Return nil. Peers with old code will stay connected, but will not be able to do anything. Peers with new
+			// code will close their network completely based on the error send above.
 			// This is to prevent the peer from being disconnected by the server making it reconnect again right away.
-			// TODO: After we implement a server protocol version we can do something better here while staying backwards compatible.
 			return nil
 		}
 

--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -216,8 +216,14 @@ func (p *Peer) HandleHelloPacket(ctx context.Context, packet HelloPacket) error 
 			return fmt.Errorf("unable to reconnect: %w", err)
 		}
 		if !hasReconnected {
-			return fmt.Errorf("unable to reconnect")
+			logger.Info("peer failed reconnecting", zap.String("game", p.Game), zap.String("peer", p.ID))
+
+			// Return nil immediately. The peer will stay connected, but will not be able to do anything.
+			// This is to prevent the peer from being disconnected by the server making it reconnect again right away.
+			// TODO: After we implement a server protocol version we can do something better here while staying backwards compatible.
+			return nil
 		}
+
 		p.Game = packet.Game
 		p.ID = packet.ID
 		p.Secret = packet.Secret

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -23,6 +23,23 @@ type errorResponse struct {
 	Errors []string `json:"errors,omitempty"`
 }
 
+type errorCodeError struct {
+	err  error
+	code string
+}
+
+func (e *errorCodeError) Error() string {
+	return e.err.Error()
+}
+
+func (e *errorCodeError) ErrorCode() string {
+	return e.code
+}
+
+func ErrorWithCode(err error, code string) error {
+	return &errorCodeError{err: err, code: code}
+}
+
 func ErrorAndAbort(w http.ResponseWriter, r *http.Request, status int, key string, errs ...error) {
 	if status/100 == 5 && len(errs) != 0 {
 		logger := logging.GetLogger(r.Context())

--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -144,7 +144,7 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
       switch (packet.type) {
         case 'error':
           {
-            const error = new SignalingError('server-error', packet.message)
+            const error = new SignalingError('server-error', packet.message, undefined, packet.code)
             this.network._onSignalingError(error)
             if (packet.code === 'missing-recipient' && packet.error?.recipient !== undefined) {
               const id = packet.error?.recipient
@@ -152,6 +152,8 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
                 this.network.log('cleaning up missing recipient', id)
                 this.connections.get(id)?.close('missing-recipient')
               }
+            } else if (packet.code === 'reconnect-failed') {
+              this.network.close('reconnect failed')
             }
           }
           break
@@ -247,7 +249,7 @@ export class SignalingError {
   /**
    * @internal
    */
-  constructor (public type: 'unknown-error' | 'socket-error' | 'server-error', public message: string, public event?: Event) {
+  constructor (public type: 'unknown-error' | 'socket-error' | 'server-error', public message: string, public event?: Event, public code?: string) {
   }
 
   public toString (): string {


### PR DESCRIPTION
Right now clients get stuck in a reconnect loop when their secret is bad. This change makes it so they don't immediately reconnect. WebRTC connections will stay in tact, so players will be able to keep playing. But they won't be able to list or join other lobbies without reloading the game.