### PR TITLE
Also ignore lingering disconnected packet

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -113,7 +113,7 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 			}
 
 			if peer.closedPacketReceived {
-				if base.Type != "disconnect" { // expected lingering packets after closure.
+				if base.Type != "disconnect" && base.Type != "disconnected" { // expected lingering packets after closure.
 					logger.Warn("received packet after close", zap.String("peer", peer.ID), zap.String("type", base.Type))
 				}
 				continue


### PR DESCRIPTION
Seeing this when debugging failing tests once in a while. Can be safely ignored.