### PR TITLE
Improve CreateLobby, JoinLobby and LeaveLobby

### DIFF
--- a/features/basic.feature
+++ b/features/basic.feature
@@ -48,8 +48,8 @@ Feature: Players can create and connect a network of players
     When "green" connects to the lobby "dhgp75mn2bll"
     And "blue" receives the network event "connected" with the argument "[Peer: ka9qy8em4vxr]"
     And "yellow" receives the network event "connected" with the argument "[Peer: ka9qy8em4vxr]"
-    And "green" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
     And "green" receives the network event "connected" with the argument "[Peer: 3t3cfgcqup9e]"
+    And "green" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
 
     When "blue" boardcasts "Hello, world!" over the reliable channel
     Then "yellow" receives the network event "message" with the arguments "[Peer: ka9qy8em4vxr]", "reliable" and "Hello, world!"

--- a/internal/signaling/stores/shared.go
+++ b/internal/signaling/stores/shared.go
@@ -17,9 +17,8 @@ type SubscriptionCallback func(context.Context, []byte)
 
 type Store interface {
 	CreateLobby(ctx context.Context, game, lobby, id string, public bool, customData map[string]any) error
-	JoinLobby(ctx context.Context, game, lobby, id string) ([]string, error)
-	IsPeerInLobby(ctx context.Context, game, lobby, id string) (bool, error)
-	LeaveLobby(ctx context.Context, game, lobby, id string) ([]string, error)
+	JoinLobby(ctx context.Context, game, lobby, id string) error
+	LeaveLobby(ctx context.Context, game, lobby, id string) error
 	GetLobby(ctx context.Context, game, lobby string) (Lobby, error)
 	ListLobbies(ctx context.Context, game, filter string) ([]Lobby, error)
 

--- a/internal/signaling/timeout_manager.go
+++ b/internal/signaling/timeout_manager.go
@@ -60,18 +60,14 @@ func (i *TimeoutManager) disconnectPeerInLobby(ctx context.Context, peerID strin
 	}
 	data, _ := json.Marshal(packet)
 
-	others, err := i.Store.LeaveLobby(ctx, gameID, lobby, peerID)
+	err := i.Store.LeaveLobby(ctx, gameID, lobby, peerID)
 	if err != nil {
 		logger.Warn("failed to leave lobby", zap.Error(err))
 		return err
 	}
-	for _, id := range others {
-		if id != peerID {
-			err := i.Store.Publish(ctx, gameID+lobby+id, data)
-			if err != nil {
-				logger.Error("failed to publish disconnect packet", zap.Error(err))
-			}
-		}
+	err = i.Store.Publish(ctx, gameID+lobby, data)
+	if err != nil {
+		logger.Error("failed to publish disconnect packet", zap.Error(err))
 	}
 	return nil
 }


### PR DESCRIPTION
Improve these functions by also adding a subscription on the lobby itself instead of only the lobby in combination with the peer. This makes it so these methods don't have to return lists of peers anymore.

Also fix the TODO to add a peer to a lobby in CreateLobby instead of calling a separate JoinLobby afterwards.

Also fixes the broken reconnect code which didn't support multiple lobbies yet.