### PR TITLE
Always work with UTC time

### DIFF
--- a/internal/metrics/client.go
+++ b/internal/metrics/client.go
@@ -76,7 +76,7 @@ func (c *Client) Record(ctx context.Context, category, action, game, peerID, lob
 
 func (c *Client) RecordEvent(ctx context.Context, params EventParams) {
 	logger := logging.GetLogger(ctx)
-	now := util.Now(ctx)
+	now := util.NowUTC(ctx)
 	remoteAddr, _ := ctx.Value(remoteAddrKey).(string)
 	userAgent, _ := ctx.Value(userAgentKey).(string)
 

--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -35,7 +35,7 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 			select {
 			case <-ticker.C:
 				logger.Info("cleaning empty lobbies")
-				if err := store.CleanEmptyLobbies(ctx, time.Now().Add(-LobbyCleanThreshold)); err != nil {
+				if err := store.CleanEmptyLobbies(ctx, util.NowUTC(ctx).Add(-LobbyCleanThreshold)); err != nil {
 					logger.Error("failed to clean empty lobbies", zap.Error(err))
 				}
 			case <-ctx.Done():

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -153,7 +153,7 @@ func (s *PostgresStore) CreateLobby(ctx context.Context, game, lobbyCode, peerID
 		logger.Warn("peer id too long", zap.String("peerID", peerID))
 		return ErrInvalidPeerID
 	}
-	now := util.Now(ctx)
+	now := util.NowUTC(ctx)
 	res, err := s.DB.Exec(ctx, `
 		INSERT INTO lobbies (code, game, public, meta, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $5)
@@ -175,7 +175,7 @@ func (s *PostgresStore) JoinLobby(ctx context.Context, game, lobbyCode, peerID s
 		return nil, ErrInvalidPeerID
 	}
 
-	now := util.Now(ctx)
+	now := util.NowUTC(ctx)
 
 	tx, err := s.DB.Begin(ctx)
 	if err != nil {
@@ -240,7 +240,7 @@ func (s *PostgresStore) IsPeerInLobby(ctx context.Context, game, lobbyCode, peer
 }
 
 func (s *PostgresStore) LeaveLobby(ctx context.Context, game, lobbyCode, peerID string) ([]string, error) {
-	now := util.Now(ctx)
+	now := util.NowUTC(ctx)
 
 	var peerlist []string
 	err := s.DB.QueryRow(ctx, `
@@ -347,7 +347,7 @@ func (s *PostgresStore) TimeoutPeer(ctx context.Context, peerID, secret, gameID 
 		}
 	}
 
-	now := util.Now(ctx)
+	now := util.NowUTC(ctx)
 	_, err := s.DB.Exec(ctx, `
 		INSERT INTO timeouts (peer, secret, game, lobbies, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $5)
@@ -387,7 +387,7 @@ func (s *PostgresStore) ReconnectPeer(ctx context.Context, peerID, secret, gameI
 }
 
 func (s *PostgresStore) ClaimNextTimedOutPeer(ctx context.Context, threshold time.Duration, callback func(peerID, gameID string, lobbies []string) error) (more bool, err error) {
-	now := util.Now(ctx)
+	now := util.NowUTC(ctx)
 
 	tx, err := s.DB.Begin(ctx)
 	if err != nil {

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -6,5 +6,5 @@ import (
 )
 
 func Now(ctx context.Context) time.Time {
-	return time.Now()
+	return time.Now().UTC()
 }

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -5,6 +5,6 @@ import (
 	"time"
 )
 
-func Now(ctx context.Context) time.Time {
+func NowUTC(ctx context.Context) time.Time {
 	return time.Now().UTC()
 }


### PR DESCRIPTION
Otherwise there are issues when running the test locally on a machine that isn't in UTC. CURRENT_TIMESTAMP in the postgress container will return a time in UTC, but time.Now() will return it in the local time which messes up the TimeoutManager.

I found this when running tests with the TimeoutManager, and noticed it was timing out peers immediately instead of after the minute that is configured.

Since we can't test the database in tests we can't write a feature test for this yet. We'll have to write this after https://github.com/poki/netlib/issues/65