### PR TITLE
Make createPlayer have a small delay

### DIFF
--- a/features/support/steps/network.ts
+++ b/features/support/steps/network.ts
@@ -9,7 +9,7 @@ After(async function (this: World) {
 })
 
 Given('{string} is connected and ready for game {string}', async function (this: World, playerName: string, gameID: string) {
-  const player = this.createPlayer(playerName, gameID)
+  const player = await this.createPlayer(playerName, gameID)
   const event = await player.waitForEvent('ready')
   if (event == null) {
     throw new Error(`unable to add player ${playerName} to network`)
@@ -96,8 +96,8 @@ Given('these lobbies exist:', async function (this: World, lobbies: DataTable) {
   })
 })
 
-When('{string} creates a network for game {string}', function (this: World, playerName: string, gameID: string) {
-  this.createPlayer(playerName, gameID)
+When('{string} creates a network for game {string}', async function (this: World, playerName: string, gameID: string) {
+  await this.createPlayer(playerName, gameID)
 })
 
 When('{string} creates a lobby', function (this: World, playerName: string) {

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -55,7 +55,7 @@ export class World extends CucumberWorld {
       // Giving this some time makes our test less flaky.
       setTimeout(() => {
         resolve(player)
-      }, 100)
+      }, 50)
     })
   }
 }

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -44,12 +44,19 @@ export class World extends CucumberWorld {
     }
   }
 
-  public createPlayer (playerName: string, gameID: string): Player {
-    const config = this.useTestProxy ? { testproxyURL: this.testproxyURL } : undefined
-    const network = new Network(gameID, config, this.signalingURL)
-    const player = new Player(playerName, network)
-    this.players.set(playerName, player)
-    return player
+  public async createPlayer (playerName: string, gameID: string): Promise<Player> {
+    return await new Promise((resolve) => {
+      const config = this.useTestProxy ? { testproxyURL: this.testproxyURL } : undefined
+      const network = new Network(gameID, config, this.signalingURL)
+      const player = new Player(playerName, network)
+      this.players.set(playerName, player)
+
+      // Give the Network some time to connect to the signaling server.
+      // Giving this some time makes our test less flaky.
+      setTimeout(() => {
+        resolve(player)
+      }, 100)
+    })
   }
 }
 setWorldConstructor(World)


### PR DESCRIPTION
Give the Network a little bit of time to connect to the signalling backend before we continue with the next step. This makes our tests less flaky. Found out when some lobby tests where we create multiple players after each other was failing because their ID was changing (as they are given out in order).