### PR TITLE
Fix test data empty array and NULL value inserts

### DIFF
--- a/features/support/steps/network.ts
+++ b/features/support/steps/network.ts
@@ -77,13 +77,17 @@ Given('these lobbies exist:', async function (this: World, lobbies: DataTable) {
           peers.push(`'peer${i}'`)
         }
 
-        v.push(`ARRAY [${peers.join(', ')}]`)
+        v.push(`ARRAY[${peers.join(', ')}]::VARCHAR(20)[]`)
       } else {
         if (!columns.includes(key)) {
           columns.push(key)
         }
 
-        v.push(`'${value}'`)
+        if (value === 'null') {
+          v.push('NULL')
+        } else {
+          v.push(`'${value}'`)
+        }
       }
     })
 


### PR DESCRIPTION
Inserting `[]` into postgress will give an error that it doesn't know the type of the array. Since we're always inserting arrays of strings here we can specify the type here.

Also converts `null` to insert `NULL` instead of the string `'NULL'`.

These are currently no in use, and because of that changes to the tests aren't needed. But I want to introduce tests with these in the Lobby Leader pull, and want to keep that pull simple and small.