### PR TITLE
Fix reconnects not being recognized

### DIFF
--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -53,7 +53,13 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
         ws.removeEventListener('error', onError)
         ws.removeEventListener('message', onMessage)
         ws.removeEventListener('close', onClose)
-        this.reconnect()
+
+        // Don't try to reconnect too quickly, give the server a chance
+        // to store our disconnection in the db, so when we reconnect
+        // it recognizes us.
+        setTimeout(() => {
+          this.reconnect()
+        }, 100)
       }
     }
     const onMessage = (ev: MessageEvent): void => {
@@ -68,7 +74,13 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
       ws.removeEventListener('error', onError)
       ws.removeEventListener('message', onMessage)
       ws.removeEventListener('close', onClose)
-      this.reconnect()
+
+      // Don't try to reconnect too quickly, give the server a chance
+      // to store our disconnection in the db, so when we reconnect
+      // it recognizes us.
+      setTimeout(() => {
+        this.reconnect()
+      }, 100)
     }
     ws.addEventListener('open', onOpen)
     ws.addEventListener('error', onError)


### PR DESCRIPTION
If we reconnect too quickly, the signalling server won't have the time to add our information to the database yet and the reconnect won't recognize us. This can be fixed by waiting a little bit before we reconnect.

When we only disconnect for shortly it will take the signaling server longer to notice the disconnect than to reconnect. In which case the reconnect isn't recognized as a disconnect.

This is still not a perfect solution and best-effort only. But from my testing where I noticed this happening it was fixed this way for now.