### PR TITLE
Given "..." is connected as "..." and ready for game "..."

### DIFF
--- a/features/basic.feature
+++ b/features/basic.feature
@@ -11,13 +11,13 @@ Feature: Players can create and connect a network of players
 
 
   Scenario: A player can create a lobby
-    Given "green" is connected and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
+    Given "green" is connected as "h5yzwyizlwao" and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
     When "green" creates a lobby
     And "green" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
 
   Scenario: A player can create a lobby with a short code
-    Given "green" is connected and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
+    Given "green" is connected as "h5yzwyizlwao" and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
     When "green" creates a lobby with these settings:
       """
       {
@@ -28,8 +28,8 @@ Feature: Players can create and connect a network of players
 
 
   Scenario: Connect two players to a lobby
-    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby
     And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
@@ -40,9 +40,9 @@ Feature: Players can create and connect a network of players
 
 
   Scenario: Connect three players to a lobby and broadcast a message
-    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "green" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "green" is connected as "ka9qy8em4vxr" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     Given "blue,yellow" are joined in a lobby
     When "green" connects to the lobby "dhgp75mn2bll"
@@ -57,9 +57,9 @@ Feature: Players can create and connect a network of players
 
 
   Scenario: A player leaves a lobby
-    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "green" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "green" is connected as "ka9qy8em4vxr" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     Given "blue,yellow,green" are joined in a lobby
     When "yellow" disconnects

--- a/features/custom-data.feature
+++ b/features/custom-data.feature
@@ -5,8 +5,8 @@ Feature: customData on lobbies can be used for filtering and extra information
 
 
   Scenario: Connect to a lobby with custom data
-    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby with these settings:
       """json

--- a/features/lobbies.feature
+++ b/features/lobbies.feature
@@ -5,21 +5,21 @@ Feature: Lobby Discovery
     And the "testproxy" backend is running
 
   Scenario: List empty lobby set
-    Given "green" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    Given "green" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     When "green" requests all lobbies
     Then "green" should receive 0 lobbies
 
   Scenario: Don't list lobbies from a different game
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "blue" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "ka9qy8em4vxr" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue,yellow" are joined in a lobby
     When "green" requests all lobbies
     Then "green" should receive 0 lobbies
 
   Scenario: List lobbies that exist
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     When "blue" creates a lobby with these settings:
       """json
@@ -36,8 +36,8 @@ Feature: Lobby Discovery
 
   Scenario: Only list public lobbies
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "yellow" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "yellow" is connected as "ka9qy8em4vxr" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     When "blue" creates a lobby with these settings:
       """json
@@ -60,7 +60,7 @@ Feature: Lobby Discovery
       | dhgp75mn2bll | 1           | true   |
 
   Scenario: Filter on playerCount
-    Given "green" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    Given "green" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     And these lobbies exist:
       | code          | game                                 | playerCount | public |
       | 0qva9vyurwbbl | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 1           | true   |
@@ -88,7 +88,7 @@ Feature: Lobby Discovery
       | 9qva9vyurwbbl | 10          | true   |
 
   Scenario: Filter on customData
-    Given "green" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    Given "green" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     And these lobbies exist:
       | code          | game                                 | playerCount | meta               | public | created_at |
       | 0qva9vyurwbbl | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 1           | {"map": "de_nuke"} | true   | 2020-01-01 |
@@ -108,7 +108,7 @@ Feature: Lobby Discovery
 
   Scenario: List empty lobbies
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     When "blue" creates a lobby with these settings:
       """json
@@ -129,7 +129,7 @@ Feature: Lobby Discovery
 
   Scenario: Filter created lobbies on customData
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     And these lobbies exist:
       | code         | game                                 | playerCount | public | meta               |

--- a/features/reconnect.feature
+++ b/features/reconnect.feature
@@ -8,8 +8,8 @@ Feature: Players can create and connect a network of players
   Scenario: Connections are reconnected before rtc is disconnected
     Given webrtc is intercepted by the testproxy
 
-    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby
     And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
@@ -28,8 +28,8 @@ Feature: Players can create and connect a network of players
   Scenario: Connections are reconnected when rtc is disconnected
     Given webrtc is intercepted by the testproxy
 
-    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby
     And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
@@ -39,9 +39,9 @@ Feature: Players can create and connect a network of players
 
     When the connection between "yellow" and "blue" is interrupted until the first "disconnected" state
 
-    And "blue" boardcasts "Goodbye, world!" over the reliable channel
     Then "yellow" receives the network event "reconnecting" with the argument "[Peer: h5yzwyizlwao]"
     And "yellow" receives the network event "reconnected" with the argument "[Peer: h5yzwyizlwao]"
+    And "blue" boardcasts "Goodbye, world!" over the reliable channel
     And "yellow" receives the network event "message" with the arguments "[Peer: h5yzwyizlwao]", "reliable" and "Goodbye, world!"
 
 
@@ -58,8 +58,8 @@ Feature: Players can create and connect a network of players
   Scenario: Two player get disconnected
     Given webrtc is intercepted by the testproxy
 
-    Given "blue" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue,yellow" are joined in a lobby
 
     When the connection between "yellow" and "blue" is interrupted
@@ -81,8 +81,8 @@ Feature: Players can create and connect a network of players
 
 
   Scenario: Reconnect with the signaling server
-    Given "green" is connected and ready for game "325a2754-1a6f-4578-b768-196463271229"
-    And "blue" is connected and ready for game "325a2754-1a6f-4578-b768-196463271229"
+    Given "green" is connected as "h5yzwyizlwao" and ready for game "325a2754-1a6f-4578-b768-196463271229"
+    And "blue" is connected as "3t3cfgcqup9e" and ready for game "325a2754-1a6f-4578-b768-196463271229"
 
     When "green" creates a lobby
     Then "green" receives the network event "lobby" with the argument "prb67ouj837u"


### PR DESCRIPTION
Implicitly show the player ID in the test step. Makes it easier to read the tests.

Also add a `Given "..." are joined in a lobby for game "..."` step that simplifies test setup.