### PR TITLE
Make dependabot group updates in a single pull weekly

### DIFF
--- a/.build/dependabot.yml
+++ b/.build/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gomod:
+        patterns:
+          - "*"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    registries:
+      - npm-yarn
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group updates of packages per ecosystem instead of single pull requests per dependency.

For example:
<img width="846" alt="Screenshot 2024-06-25 at 09 08 41" src="https://github.com/poki/netlib/assets/522870/7c9e51d1-51c5-4985-a352-a726fb6b128d">
