### PR TITLE
Only expire the temporary postgres in tests

### DIFF
--- a/internal/signaling/stores/setup.go
+++ b/internal/signaling/stores/setup.go
@@ -60,8 +60,11 @@ func FromEnv(ctx context.Context) (Store, chan struct{}, error) {
 			pool.Purge(resource) // nolint:errcheck
 			close(flushed)
 		}()
-		if err := resource.Expire(120); err != nil {
-			return nil, nil, err
+		if os.Getenv("ENV") == "test" {
+			// Automatically expire the container after 120 seconds in tests.
+			if err := resource.Expire(120); err != nil {
+				return nil, nil, err
+			}
 		}
 		databaseUrl := fmt.Sprintf("postgres://test:test@%s/test?sslmode=disable", resource.GetHostPort("5432/tcp"))
 


### PR DESCRIPTION
When just running 'go run cmd/signaling/main.go' for local testing you don't want the database to expire.