### PR TITLE
Make "failed to update lobby" a warning, and add information

### DIFF
--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -470,7 +470,7 @@ func (p *Peer) HandleUpdatePacket(ctx context.Context, packet LobbyUpdatePacket)
 
 	err := p.store.UpdateCustomData(ctx, p.Game, p.Lobby, p.ID, packet.Public, packet.CustomData, packet.CanUpdateBy)
 	if err != nil {
-		logger.Error("failed to update lobby", zap.Error(err), zap.Any("customData", packet.CustomData))
+		logger.Warn("failed to update lobby", zap.Error(err), zap.Any("customData", packet.CustomData))
 		util.ReplyError(ctx, p.conn, fmt.Errorf("unable to update lobby: %v", err))
 		return nil
 	}

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -634,14 +634,14 @@ func (s *PostgresStore) UpdateCustomData(ctx context.Context, game, lobby, peer 
 		// No restrictions.
 	case CanUpdateByCreator:
 		if creator != peer {
-			return ErrNotAllowed
+			return errors.New("not allowed: peer is not the creator")
 		}
 	case CanUpdateByLeader:
 		if leader != peer {
-			return ErrNotAllowed
+			return errors.New("not allowed: peer is not the leader")
 		}
 	default:
-		return ErrNotAllowed
+		return fmt.Errorf("invalid can_update_by value: %q", currentCanUpdateBy)
 	}
 
 	columns := make([]string, 0, 3)

--- a/internal/signaling/stores/shared.go
+++ b/internal/signaling/stores/shared.go
@@ -12,7 +12,6 @@ var ErrNotFound = errors.New("lobby not found")
 var ErrNoSuchTopic = errors.New("no such topic")
 var ErrInvalidLobbyCode = errors.New("invalid lobby code")
 var ErrInvalidPeerID = errors.New("invalid peer id")
-var ErrNotAllowed = errors.New("not allowed")
 
 type SubscriptionCallback func(context.Context, []byte)
 


### PR DESCRIPTION
This gets triggered by developers building their game and trying things. No need to log it as an error. Also add the reason why the update was not allowed so we can see what is happening most.