### PR TITLE
Rename IsPipeError to ShouldIgnoreNetworkError

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -89,7 +89,7 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 			for {
 				select {
 				case <-ticker.C:
-					if err := peer.Send(ctx, PingPacket{Type: "ping"}); err != nil && !util.IsPipeError(err) {
+					if err := peer.Send(ctx, PingPacket{Type: "ping"}); err != nil && !util.ShouldIgnoreNetworkError(err) {
 						logger.Error("failed to send ping packet", zap.String("peer", peer.ID), zap.Error(err))
 					}
 				case <-ctx.Done():

--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -71,7 +71,7 @@ func (p *Peer) ForwardMessage(ctx context.Context, raw []byte) {
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 	err := p.conn.Write(ctx, websocket.MessageText, raw)
-	if err != nil && !util.IsPipeError(err) {
+	if err != nil && !util.ShouldIgnoreNetworkError(err) {
 		logger.Warn("failed to forward message", zap.Error(err))
 	}
 }


### PR DESCRIPTION
And also ignore net.ErrClosed (use of closed network connection), which started happening after the last websocket update, which changed how closing of websockets is done.

See: https://github.com/nhooyr/websocket/releases/tag/v1.8.11