### PR TITLE
Upgrade test and mod file to Go 1.23.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.3'
+        go-version: '1.23.1'
     - run: yarn install --frozen-lockfile
     - run: yarn lint
     - run: yarn cucumber

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/poki/netlib
 
-go 1.22.3
+go 1.23.1
 
 require (
 	github.com/coder/websocket v1.8.12


### PR DESCRIPTION
Make sure we run the tests with the same Go version we deploy with.