### PR TITLE
Add Cache-Control: no-store

### DIFF
--- a/cmd/signaling/main.go
+++ b/cmd/signaling/main.go
@@ -52,7 +52,9 @@ func main() {
 	mux, cleanup := internal.Signaling(ctx, store, credentialsClient)
 
 	cors := cors.Default()
-	handler := logging.Middleware(cors.Handler(mux), logger)
+	handler := cors.Handler(mux)
+	handler = util.NoStoreMiddleware(handler)
+	handler = logging.Middleware(handler, logger)
 
 	if metricsURL, ok := os.LookupEnv("METRICS_URL"); ok {
 		client := metrics.NewClient(metricsURL)

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -154,7 +154,9 @@ func ShouldIgnoreNetworkError(err error) bool {
 
 func NoStoreMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "no-store")
+		if r.Method == http.MethodGet {
+			w.Header().Set("Cache-Control", "no-store")
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -151,3 +151,10 @@ func ShouldIgnoreNetworkError(err error) bool {
 	}
 	return false
 }
+
+func NoStoreMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/util/http_test.go
+++ b/internal/util/http_test.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNoStoreMiddleware(t *testing.T) {
+	sampleHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := NoStoreMiddleware(sampleHandler)
+
+	req, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Fatalf("Could not create request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	expectedCacheControl := "no-store"
+	if rr.Header().Get("Cache-Control") != expectedCacheControl {
+		t.Errorf("expected Cache-Control header to be %v, got %v",
+			expectedCacheControl, rr.Header().Get("Cache-Control"))
+	}
+}

--- a/internal/util/http_test.go
+++ b/internal/util/http_test.go
@@ -13,18 +13,27 @@ func TestNoStoreMiddleware(t *testing.T) {
 
 	handler := NoStoreMiddleware(sampleHandler)
 
-	req, err := http.NewRequest("GET", "/test", nil)
-	if err != nil {
-		t.Fatalf("Could not create request: %v", err)
+	tests := []struct {
+		method               string
+		expectedCacheControl string
+	}{
+		{"GET", "no-store"},
+		{"POST", ""},
 	}
 
-	rr := httptest.NewRecorder()
+	for _, tt := range tests {
+		req, err := http.NewRequest(tt.method, "/test", nil)
+		if err != nil {
+			t.Fatalf("Could not create %v request: %v", tt.method, err)
+		}
 
-	handler.ServeHTTP(rr, req)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
 
-	expectedCacheControl := "no-store"
-	if rr.Header().Get("Cache-Control") != expectedCacheControl {
-		t.Errorf("expected Cache-Control header to be %v, got %v",
-			expectedCacheControl, rr.Header().Get("Cache-Control"))
+		actualCacheControl := recorder.Header().Get("Cache-Control")
+		if actualCacheControl != tt.expectedCacheControl {
+			t.Errorf("expected Cache-Control header to be %q for %v request, got %q",
+				tt.expectedCacheControl, tt.method, actualCacheControl)
+		}
 	}
 }


### PR DESCRIPTION
I want to proxy this service behind Cloudflare in order to hide its IP. Cloudflare has its own rules for what to cache and how long. I don't want to rely on that, this force it to never cache.