### PR TITLE
Ignore broken pipe

### DIFF
--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -128,6 +128,9 @@ func ShouldIgnoreNetworkError(err error) bool {
 	case syscall.Errno:
 		return v == syscall.EPIPE
 	case *net.OpError:
+		if v.Op == "write" && strings.Contains(v.Error(), "broken pipe") {
+			return true
+		}
 		return ShouldIgnoreNetworkError(v.Err)
 	case *os.SyscallError:
 		return ShouldIgnoreNetworkError(v.Err)


### PR DESCRIPTION
Seeing this error a lot. It's nested in such a way that we can't seem to Unwrap it, so do string matching.