### PR TITLE
Ignore broken pipe v2

### DIFF
--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -124,13 +124,13 @@ func WithRequestID(ctx context.Context, id string) context.Context {
 }
 
 func ShouldIgnoreNetworkError(err error) bool {
+	if strings.Contains(err.Error(), "write: broken pipe") {
+		return true
+	}
 	switch v := err.(type) {
 	case syscall.Errno:
 		return v == syscall.EPIPE
 	case *net.OpError:
-		if v.Op == "write" && strings.Contains(v.Error(), "broken pipe") {
-			return true
-		}
 		return ShouldIgnoreNetworkError(v.Err)
 	case *os.SyscallError:
 		return ShouldIgnoreNetworkError(v.Err)

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -131,9 +131,6 @@ func ShouldIgnoreNetworkError(err error) bool {
 	case syscall.Errno:
 		return v == syscall.EPIPE
 	case *net.OpError:
-		if v.Op == "write" && strings.Contains(v.Error(), "broken pipe") {
-			return true
-		}
 		return ShouldIgnoreNetworkError(v.Err)
 	case *os.SyscallError:
 		return ShouldIgnoreNetworkError(v.Err)

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -128,6 +128,9 @@ func ShouldIgnoreNetworkError(err error) bool {
 	case syscall.Errno:
 		return v == syscall.EPIPE
 	case *net.OpError:
+		if v.Op == "write" && strings.Contains(v.Error(), "broken pipe") {
+			return true
+		}
 		return ShouldIgnoreNetworkError(v.Err)
 	case *os.SyscallError:
 		return ShouldIgnoreNetworkError(v.Err)


### PR DESCRIPTION
The other attempt did not work as the broken pipe error might have been too nested. With this change we try to catch it at the top-level.