### PR TITLE
Log broken pipe errors as warnings

### DIFF
--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -124,9 +124,6 @@ func WithRequestID(ctx context.Context, id string) context.Context {
 }
 
 func ShouldIgnoreNetworkError(err error) bool {
-	if strings.Contains(err.Error(), "write: broken pipe") {
-		return true
-	}
 	switch v := err.(type) {
 	case syscall.Errno:
 		return v == syscall.EPIPE


### PR DESCRIPTION
There is something strange causing these errors which also prevents people from joining lobbies. Log the errors as warnings so we can at least investigate them, but they won't show up in Poki's error logging tools.