### PR TITLE
Replace ManagedCertificate with Certificate

### DIFF
--- a/manifest/deployment.yaml
+++ b/manifest/deployment.yaml
@@ -16,7 +16,8 @@ spec:
       - name: signaling
         image: "europe-docker.pkg.dev/poki-core/netlib/signaling:$GITHUB_SHA"
         ports:
-        - containerPort: 8080
+        - name: signaling
+          containerPort: 8080
         env:
         - name: ENV
           value: production

--- a/manifest/ingress.yaml
+++ b/manifest/ingress.yaml
@@ -8,9 +8,10 @@ spec:
   selector:
     deployment: signaling
   ports:
-  - protocol: TCP
+  - name: http
+    protocol: TCP
     port: 8080
-    targetPort: 8080
+    targetPort: signaling
 ---
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
@@ -27,9 +28,10 @@ metadata:
   annotations:
     # gcloud compute addresses create netlib --global
     kubernetes.io/ingress.global-static-ip-name: netlib
-    networking.gke.io/managed-certificates: netlib.poki.io
     kubernetes.io/ingress.allow-http: "false"
 spec:
+  tls:
+  - secretName: netlib-ssl
   rules:
   - host: netlib.poki.io
     http:
@@ -40,7 +42,7 @@ spec:
           service:
             name: netlib-signaling
             port:
-              number: 8080
+              name: http
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig

--- a/manifest/kustomization.yaml
+++ b/manifest/kustomization.yaml
@@ -6,3 +6,4 @@ commonLabels:
 resources:
 - deployment.yaml
 - ingress.yaml
+- ssl-certificate.yaml

--- a/manifest/rbac.yaml
+++ b/manifest/rbac.yaml
@@ -39,9 +39,9 @@ rules:
     - update
     - create
     - patch
-- apiGroups: ["networking.gke.io"]
+- apiGroups: ["cert-manager.io"]
   resources:
-    - managedCertificates
+    - certificates
   verbs:
     - get
     - update

--- a/manifest/ssl-certificate.yaml
+++ b/manifest/ssl-certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: netlib
+spec:
+  secretName: netlib-ssl
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - netlib.poki.io


### PR DESCRIPTION
We put the ingress behind cloudflare. Cloudflare will intercept requests and prevent Google's domain validation protocol from working. We set up cert-manager to get around this problem.

Don't forget to apply the RBAC before merging! ⚠️ 