### PR TITLE
Fix the exit code in case of 'cucumber did not exit cleanly'

### DIFF
--- a/features/leader.feature
+++ b/features/leader.feature
@@ -65,7 +65,7 @@ Feature: Lobbies have a leader that can control the lobby
           "playerCount": 1,
           "creator": "foo",
           "public": true,
-          "maxPlayers": 4,
+          "maxPlayers": 64,
           "hasPassword": false,
           "customData": {
             "map": "de_nuke"

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -16,6 +16,8 @@ import { Network } from '../../lib'
 
 process.env.NODE_ENV = 'test'
 
+let anyScenarioFailed = false
+
 interface backend {
   process: ReturnType<typeof spawn>
   port: number
@@ -92,13 +94,17 @@ AfterAll(function () {
 
   setTimeout(() => {
     console.log('cucumber did not exit cleanly, forcing exit')
-    process.exit(0)
-  }, 1000).unref()
+    process.exit(anyScenarioFailed ? 1 : 0)
+  }, 2000).unref()
 })
 
 Before(function (this: World) {
   this.scenarioRunning = true
 })
-After(function (this: World) {
+After(function (this: World, { result }) {
   this.scenarioRunning = false
+
+  if (result?.status === 'FAILED') {
+    anyScenarioFailed = true
+  }
 })


### PR DESCRIPTION
This apparently happens a lot in our CI. We had it exit with status code 0 instead of when a step actually failed.

See for example: https://github.com/poki/netlib/actions/runs/12979606225/job/36195532784#step:6:100