### PR TITLE
Make tests deterministic

### DIFF
--- a/features/basic.feature
+++ b/features/basic.feature
@@ -7,62 +7,62 @@ Feature: Players can create and connect a network of players
   Scenario: A player can create a network to join a game
     When "green" creates a network for game "164aae2e-c6e5-4073-80bf-b2a03ad4c9b7"
     Then "green" receives the network event "ready"
-    And "green" has recieved the peer ID "h5yzwyizlwao"
+    And "green" has recieved the peer ID "1u8fw4aph5ypt"
 
 
   Scenario: A player can create a lobby
-    Given "green" is connected as "h5yzwyizlwao" and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
+    Given "green" is connected as "1u8fw4aph5ypt" and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
     When "green" creates a lobby
-    And "green" receives the network event "lobby" with the argument "19yrzmetd2bn7"
+    And "green" receives the network event "lobby" with the argument "h5yzwyizlwao"
 
 
   Scenario: A player can create a lobby with a short code
-    Given "green" is connected as "h5yzwyizlwao" and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
+    Given "green" is connected as "1u8fw4aph5ypt" and ready for game "b6f7fc97-8545-4ffd-b714-7cf339048556"
     When "green" creates a lobby with these settings:
       """
       {
         "codeFormat": "short"
       }
       """
-    And "green" receives the network event "lobby" with the argument "34SB"
+    And "green" receives the network event "lobby" with the argument "43ES"
 
 
   Scenario: Connect two players to a lobby
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
-    When "yellow" connects to the lobby "prb67ouj837u"
-    And "blue" receives the network event "connected" with the argument "[Peer: 3t3cfgcqup9e]"
-    And "yellow" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
+    When "yellow" connects to the lobby "19yrzmetd2bn7"
+    And "blue" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
+    And "yellow" receives the network event "connected" with the argument "[Peer: 1u8fw4aph5ypt]"
 
 
   Scenario: Connect three players to a lobby and broadcast a message
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "green" is connected as "ka9qy8em4vxr" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "green" is connected as "19yrzmetd2bn7" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     Given "blue,yellow" are joined in a lobby
-    When "green" connects to the lobby "dhgp75mn2bll"
-    And "blue" receives the network event "connected" with the argument "[Peer: ka9qy8em4vxr]"
-    And "yellow" receives the network event "connected" with the argument "[Peer: ka9qy8em4vxr]"
-    And "green" receives the network event "connected" with the argument "[Peer: 3t3cfgcqup9e]"
+    When "green" connects to the lobby "3t3cfgcqup9e"
+    And "blue" receives the network event "connected" with the argument "[Peer: 19yrzmetd2bn7]"
+    And "yellow" receives the network event "connected" with the argument "[Peer: 19yrzmetd2bn7]"
+    And "green" receives the network event "connected" with the argument "[Peer: 1u8fw4aph5ypt]"
     And "green" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
 
     When "blue" boardcasts "Hello, world!" over the reliable channel
-    Then "yellow" receives the network event "message" with the arguments "[Peer: ka9qy8em4vxr]", "reliable" and "Hello, world!"
-    And "green" receives the network event "message" with the arguments "[Peer: ka9qy8em4vxr]", "reliable" and "Hello, world!"
+    Then "yellow" receives the network event "message" with the arguments "[Peer: 19yrzmetd2bn7]", "reliable" and "Hello, world!"
+    And "green" receives the network event "message" with the arguments "[Peer: 19yrzmetd2bn7]", "reliable" and "Hello, world!"
 
 
   Scenario: A player leaves a lobby
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "green" is connected as "ka9qy8em4vxr" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "green" is connected as "19yrzmetd2bn7" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     Given "blue,yellow,green" are joined in a lobby
     When "yellow" disconnects
     Then "yellow" receives the network event "close"
-    Then "blue" receives the network event "disconnected" with the argument "[Peer: 3t3cfgcqup9e]"
-    Then "green" receives the network event "disconnected" with the argument "[Peer: 3t3cfgcqup9e]"
+    Then "blue" receives the network event "disconnected" with the argument "[Peer: h5yzwyizlwao]"
+    Then "green" receives the network event "disconnected" with the argument "[Peer: h5yzwyizlwao]"

--- a/features/custom-data.feature
+++ b/features/custom-data.feature
@@ -5,8 +5,8 @@ Feature: customData on lobbies can be used for filtering and extra information
 
 
   Scenario: Connect to a lobby with custom data
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby with these settings:
       """json
@@ -21,14 +21,14 @@ Feature: customData on lobbies can be used for filtering and extra information
     Then "blue" receives the network event "lobby" with the arguments:
       """json
       [
-        "prb67ouj837u",
+        "19yrzmetd2bn7",
         {
-          "code": "prb67ouj837u",
+          "code": "19yrzmetd2bn7",
           "peers": [
-            "h5yzwyizlwao"
+            "1u8fw4aph5ypt"
           ],
           "playerCount": 1,
-          "creator": "h5yzwyizlwao",
+          "creator": "1u8fw4aph5ypt",
           "public": true,
           "maxPlayers": 4,
           "hasPassword": false,
@@ -37,25 +37,25 @@ Feature: customData on lobbies can be used for filtering and extra information
             "map": "de_dust2"
           },
           "canUpdateBy": "creator",
-          "leader": "h5yzwyizlwao",
+          "leader": "1u8fw4aph5ypt",
           "term": 1
         }
       ]
       """
 
-    When "yellow" connects to the lobby "prb67ouj837u"
+    When "yellow" connects to the lobby "19yrzmetd2bn7"
     Then "yellow" receives the network event "lobby" with the arguments:
       """json
       [
-        "prb67ouj837u",
+        "19yrzmetd2bn7",
         {
-          "code": "prb67ouj837u",
+          "code": "19yrzmetd2bn7",
           "peers": [
-            "3t3cfgcqup9e",
+            "1u8fw4aph5ypt",
             "h5yzwyizlwao"
           ],
           "playerCount": 2,
-          "creator": "h5yzwyizlwao",
+          "creator": "1u8fw4aph5ypt",
           "public": true,
           "maxPlayers": 4,
           "hasPassword": false,
@@ -64,7 +64,7 @@ Feature: customData on lobbies can be used for filtering and extra information
             "map": "de_dust2"
           },
           "canUpdateBy": "creator",
-          "leader": "h5yzwyizlwao",
+          "leader": "1u8fw4aph5ypt",
           "term": 1
         }
       ]
@@ -72,8 +72,8 @@ Feature: customData on lobbies can be used for filtering and extra information
 
 
   Scenario: The creator can edit a lobby
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "yellow" creates a lobby with these settings:
       """json
       {
@@ -83,7 +83,7 @@ Feature: customData on lobbies can be used for filtering and extra information
         }
       }
       """
-    And "yellow" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "yellow" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
     When "blue" requests lobbies with this filter:
       """json
@@ -92,8 +92,8 @@ Feature: customData on lobbies can be used for filtering and extra information
       }
       """
     Then "blue" should have received only these lobbies:
-      | code         |
-      | prb67ouj837u |
+      | code          |
+      | 19yrzmetd2bn7 |
 
     When "yellow" updates the lobby with these settings:
       """json
@@ -115,7 +115,7 @@ Feature: customData on lobbies can be used for filtering and extra information
 
 
   Scenario: The creator can set can_update_by
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
@@ -123,7 +123,7 @@ Feature: customData on lobbies can be used for filtering and extra information
         "canUpdateBy": "creator"
       }
       """
-    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
+    And "blue" receives the network event "lobby" with the argument "h5yzwyizlwao"
 
     When "blue" updates the lobby with these settings:
       """json
@@ -142,17 +142,17 @@ Feature: customData on lobbies can be used for filtering and extra information
 
 
   Scenario: Other players can update the lobby if canUpdateBy is 'anyone'
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
         "canUpdateBy": "anyone"
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
-    And "yellow" connects to the lobby "prb67ouj837u"
-    And "yellow" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
+    And "yellow" connects to the lobby "19yrzmetd2bn7"
+    And "yellow" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
     When "yellow" updates the lobby with these settings:
       """json
@@ -162,20 +162,20 @@ Feature: customData on lobbies can be used for filtering and extra information
         }
       }
       """
-    Then "yellow" receives the network event "lobbyUpdated" with the argument "prb67ouj837u"
+    Then "yellow" receives the network event "lobbyUpdated" with the argument "19yrzmetd2bn7"
 
 
   Scenario: The creator can update the lobby when canUpdateBy is 'creator' and they are not the leader
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
         "canUpdateBy": "creator"
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
-    And "yellow" connects to the lobby "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
+    And "yellow" connects to the lobby "19yrzmetd2bn7"
     And "blue" disconnected from the signaling server
     And "yellow" becomes the leader of the lobby
     And "blue" receives the network event "signalingreconnected"
@@ -188,19 +188,19 @@ Feature: customData on lobbies can be used for filtering and extra information
         }
       }
       """
-    Then "blue" receives the network event "lobbyUpdated" with the argument "prb67ouj837u"
+    Then "blue" receives the network event "lobbyUpdated" with the argument "19yrzmetd2bn7"
     And "yellow" receives the network event "lobbyUpdated" with the arguments:
       """json
       [
-        "prb67ouj837u",
+        "19yrzmetd2bn7",
         {
-          "code": "prb67ouj837u",
+          "code": "19yrzmetd2bn7",
           "peers": [
-            "3t3cfgcqup9e",
+            "1u8fw4aph5ypt",
             "h5yzwyizlwao"
           ],
           "playerCount": 2,
-          "creator": "h5yzwyizlwao",
+          "creator": "1u8fw4aph5ypt",
           "public": false,
           "maxPlayers": 4,
           "hasPassword": false,
@@ -208,7 +208,7 @@ Feature: customData on lobbies can be used for filtering and extra information
             "status": "started"
           },
           "canUpdateBy": "creator",
-          "leader": "3t3cfgcqup9e",
+          "leader": "h5yzwyizlwao",
           "term": 2
         }
       ]
@@ -216,16 +216,16 @@ Feature: customData on lobbies can be used for filtering and extra information
 
 
   Scenario: The leader can update the lobby if they are not the creator
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
         "canUpdateBy": "leader"
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
-    And "yellow" connects to the lobby "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
+    And "yellow" connects to the lobby "19yrzmetd2bn7"
     And "blue" disconnects
     And "blue" receives the network event "close"
     And "yellow" becomes the leader of the lobby
@@ -238,4 +238,4 @@ Feature: customData on lobbies can be used for filtering and extra information
         }
       }
       """
-    Then "yellow" receives the network event "lobbyUpdated" with the argument "prb67ouj837u"
+    Then "yellow" receives the network event "lobbyUpdated" with the argument "19yrzmetd2bn7"

--- a/features/leader.feature
+++ b/features/leader.feature
@@ -6,30 +6,30 @@ Feature: Lobbies have a leader that can control the lobby
 
 
   Scenario: Other players see the creator as the leader
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
-    When "yellow" connects to the lobby "prb67ouj837u"
+    When "yellow" connects to the lobby "19yrzmetd2bn7"
     Then "yellow" receives the network event "lobby" with the arguments:
-    """json
+      """json
       [
-        "prb67ouj837u",
+        "19yrzmetd2bn7",
         {
-          "code": "prb67ouj837u",
+          "code": "19yrzmetd2bn7",
           "peers": [
-            "3t3cfgcqup9e",
+            "1u8fw4aph5ypt",
             "h5yzwyizlwao"
           ],
           "playerCount": 2,
-          "creator": "h5yzwyizlwao",
+          "creator": "1u8fw4aph5ypt",
           "public": false,
           "maxPlayers": 4,
           "hasPassword": false,
           "customData": null,
           "canUpdateBy": "creator",
-          "leader": "h5yzwyizlwao",
+          "leader": "1u8fw4aph5ypt",
           "term": 1
         }
       ]
@@ -42,12 +42,12 @@ Feature: Lobbies have a leader that can control the lobby
 
     When "blue" disconnects
     Then "green" becomes the leader of the lobby
-    And "yellow" receives the network event "leader" with the argument "ka9qy8em4vxr"
-    And "green" receives the network event "leader" with the argument "ka9qy8em4vxr"
+    And "yellow" receives the network event "leader" with the argument "19yrzmetd2bn7"
+    And "green" receives the network event "leader" with the argument "19yrzmetd2bn7"
 
 
   Scenario: Joining an empty lobby makes you the leader
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And these lobbies exist:
       | code         | game                                 | playerCount | public | custom_data        | creator |
       | 1qva9vyurwbb | 4307bd86-e1df-41b8-b9df-e22afcf084bd | 0           | true   | {"map": "de_nuke"} | foo     |
@@ -60,7 +60,7 @@ Feature: Lobbies have a leader that can control the lobby
         {
           "code": "1qva9vyurwbb",
           "peers": [
-            "h5yzwyizlwao"
+            "1u8fw4aph5ypt"
           ],
           "playerCount": 1,
           "creator": "foo",
@@ -71,7 +71,7 @@ Feature: Lobbies have a leader that can control the lobby
             "map": "de_nuke"
           },
           "canUpdateBy": "creator",
-          "leader": "h5yzwyizlwao",
+          "leader": "1u8fw4aph5ypt",
           "term": 1
         }
       ]
@@ -80,10 +80,10 @@ Feature: Lobbies have a leader that can control the lobby
 
   Scenario: A player reconnects when a websocket gets a leader event
     Given "blue,yellow,green" are joined in a lobby for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    
+
     When "yellow" disconnected from the signaling server
     And "blue" disconnected from the signaling server
     Then "green" becomes the leader of the lobby
 
     When "yellow" receives the network event "signalingreconnected"
-    Then "yellow" receives the network event "leader" with the argument "ka9qy8em4vxr"
+    Then "yellow" receives the network event "leader" with the argument "19yrzmetd2bn7"

--- a/features/lobbies.feature
+++ b/features/lobbies.feature
@@ -5,21 +5,21 @@ Feature: Lobby Discovery
     And the "testproxy" backend is running
 
   Scenario: List empty lobby set
-    Given "green" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    Given "green" is connected as "1u8fw4aph5ypt" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     When "green" requests all lobbies
     Then "green" should receive 0 lobbies
 
   Scenario: Don't list lobbies from a different game
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "ka9qy8em4vxr" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "19yrzmetd2bn7" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue,yellow" are joined in a lobby
     When "green" requests all lobbies
     Then "green" should receive 0 lobbies
 
   Scenario: List lobbies that exist
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     When "blue" creates a lobby with these settings:
       """json
@@ -27,17 +27,17 @@ Feature: Lobby Discovery
         "public": true
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
     When "green" requests all lobbies
     Then "green" should have received only these lobbies:
-      | code         | playerCount |
-      | prb67ouj837u | 1           |
+      | code          | playerCount |
+      | 19yrzmetd2bn7 | 1           |
 
   Scenario: Only list public lobbies
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "yellow" is connected as "ka9qy8em4vxr" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "yellow" is connected as "19yrzmetd2bn7" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     When "blue" creates a lobby with these settings:
       """json
@@ -45,22 +45,22 @@ Feature: Lobby Discovery
         "public": true
       }
       """
-    And "blue" receives the network event "lobby" with the argument "dhgp75mn2bll"
+    And "blue" receives the network event "lobby" with the argument "3t3cfgcqup9e"
     And "yellow" creates a lobby with these settings:
       """json
       {
         "public": false
       }
       """
-    And "yellow" receives the network event "lobby" with the argument "1qva9vyurwbbl"
+    And "yellow" receives the network event "lobby" with the argument "prb67ouj837u"
 
     When "green" requests all lobbies
     Then "green" should have received only these lobbies:
       | code         | playerCount | public |
-      | dhgp75mn2bll | 1           | true   |
+      | 3t3cfgcqup9e | 1           | true   |
 
   Scenario: Filter on playerCount
-    Given "green" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    Given "green" is connected as "1u8fw4aph5ypt" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     And these lobbies exist:
       | code          | game                                 | playerCount | public |
       | 0qva9vyurwbbl | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 1           | true   |
@@ -77,7 +77,9 @@ Feature: Lobby Discovery
     When "green" requests lobbies with this filter:
       """json
       {
-        "playerCount": {"$gte": 5}
+        "playerCount": {
+          "$gte": 5
+        }
       }
       """
     Then "green" should have received only these lobbies:
@@ -88,18 +90,20 @@ Feature: Lobby Discovery
       | 9qva9vyurwbbl | 10          | true   |
 
   Scenario: Filter on customData
-    Given "green" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    Given "green" is connected as "1u8fw4aph5ypt" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
     And these lobbies exist:
       | code          | game                                 | playerCount | custom_data        | public | created_at |
       | 0qva9vyurwbbl | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 1           | {"map": "de_nuke"} | true   | 2020-01-01 |
-      | 1qva9vyurwbbl | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 1           | {"map": "de_dust"} | true   | 2020-01-02 | 
+      | 1qva9vyurwbbl | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 1           | {"map": "de_dust"} | true   | 2020-01-02 |
       | 2qva9vyurwbbl | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 1           | {"map": "de_nuke"} | true   | 2020-01-03 |
 
     When "green" requests lobbies with this filter:
       """json
       {
         "map": "de_nuke",
-        "createdAt": {"$gte": "2020-01-02"}
+        "createdAt": {
+          "$gte": "2020-01-02"
+        }
       }
       """
     Then "green" should have received only these lobbies:
@@ -108,7 +112,7 @@ Feature: Lobby Discovery
 
   Scenario: List empty lobbies
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     When "blue" creates a lobby with these settings:
       """json
@@ -117,7 +121,7 @@ Feature: Lobby Discovery
         "public": true
       }
       """
-    And "blue" receives the network event "lobby" with the argument "52YS"
+    And "blue" receives the network event "lobby" with the argument "34SB"
 
     When "blue" disconnects
     Then "blue" receives the network event "close"
@@ -125,15 +129,15 @@ Feature: Lobby Discovery
     When "green" requests all lobbies
     Then "green" should have received only these lobbies:
       | code | playerCount |
-      | 52YS | 0           |
+      | 34SB | 0           |
 
   Scenario: Filter created lobbies on customData
     Given "green" creates a network for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
-    And "blue" is connected as "3t3cfgcqup9e" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
+    And "blue" is connected as "h5yzwyizlwao" and ready for game "f666036d-d9e1-4d70-b0c3-4a68b24a9884"
 
     And these lobbies exist:
       | code         | game                                 | playerCount | public | custom_data        |
-      | 1qva9vyurwbb | 54fa57d5-b4bd-401d-981d-2c13de99be27 | 9           | true   | {"map": "de_nuke"} | # different game
+      | 1qva9vyurwbb | 54fa57d5-b4bd-401d-981d-2c13de99be27 | 9           | true   | {"map": "de_nuke"} |
       | 2qva9vyurwbb | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 10          | true   | {"map": "de_dust"} |
       | 3qva9vyurwbb | f666036d-d9e1-4d70-b0c3-4a68b24a9884 | 10          | true   | {"map": "de_nuke"} |
 
@@ -146,7 +150,7 @@ Feature: Lobby Discovery
         }
       }
       """
-    And "green" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "green" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
     When "blue" requests lobbies with this filter:
       """json
@@ -155,6 +159,6 @@ Feature: Lobby Discovery
       }
       """
     Then "blue" should have received only these lobbies:
-      | code         |
-      | prb67ouj837u |
-      | 3qva9vyurwbb |
+      | code          |
+      | 19yrzmetd2bn7 |
+      | 3qva9vyurwbb  |

--- a/features/maxPlayers.feature
+++ b/features/maxPlayers.feature
@@ -5,9 +5,9 @@ Feature: Lobbies can have a maximum number of players
 
 
   Scenario: Players can set a maximum number of players for a lobby
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "green" is connected as "ka9qy8em4vxr" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "green" is connected as "19yrzmetd2bn7" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     And "blue" creates a lobby with these settings:
       """json
@@ -15,13 +15,13 @@ Feature: Lobbies can have a maximum number of players
         "maxPlayers": 2
       }
       """
-    And "blue" receives the network event "lobby" with the argument "dhgp75mn2bll"
+    And "blue" receives the network event "lobby" with the argument "3t3cfgcqup9e"
 
-    When "yellow" connects to the lobby "dhgp75mn2bll"
-    Then "yellow" receives the network event "lobby" with the argument "dhgp75mn2bll"
+    When "yellow" connects to the lobby "3t3cfgcqup9e"
+    Then "yellow" receives the network event "lobby" with the argument "3t3cfgcqup9e"
 
     # The lobby is full
-    When "green" tries to connect to the lobby "dhgp75mn2bll" without a password
+    When "green" tries to connect to the lobby "3t3cfgcqup9e" without a password
     Then "green" failed to join the lobby
     And the latest error for "green" is "lobby is full"
 
@@ -29,28 +29,27 @@ Feature: Lobbies can have a maximum number of players
     Then "yellow" receives the network event "close"
 
     # The lobby is not full anymore
-    When "green" connects to the lobby "dhgp75mn2bll"
-    Then "green" receives the network event "lobby" with the argument "dhgp75mn2bll"
+    When "green" connects to the lobby "3t3cfgcqup9e"
+    Then "green" receives the network event "lobby" with the argument "3t3cfgcqup9e"
 
 
   Scenario: You can update the maximum number of players for a lobby
-    Given "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "yellow" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "yellow" creates a lobby with these settings:
       """json
       {
         "public": true
       }
       """
-    And "yellow" receives the network event "lobby" with the argument "19yrzmetd2bn7"
+    And "yellow" receives the network event "lobby" with the argument "h5yzwyizlwao"
 
     When "yellow" requests lobbies with this filter:
       """json
-      {
-      }
+      {}
       """
     Then "yellow" should have received only these lobbies:
-      | code          | maxPlayers |
-      | 19yrzmetd2bn7 | 4          |
+      | code         | maxPlayers |
+      | h5yzwyizlwao | 4          |
 
     When "yellow" updates the lobby with these settings:
       """json
@@ -61,9 +60,8 @@ Feature: Lobbies can have a maximum number of players
 
     When "yellow" requests lobbies with this filter:
       """json
-      {
-      }
+      {}
       """
     Then "yellow" should have received only these lobbies:
-      | code          | maxPlayers |
-      | 19yrzmetd2bn7 | 12         |
+      | code         | maxPlayers |
+      | h5yzwyizlwao | 12         |

--- a/features/password.feature
+++ b/features/password.feature
@@ -5,54 +5,54 @@ Feature: Lobbies can be password protected
 
 
   Scenario: Players can create password protected lobbies and join them
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
         "password": "foobar"
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
-    When "yellow" connects to the lobby "prb67ouj837u" with the password "foobar"
-    Then "yellow" receives the network event "lobby" with the argument "prb67ouj837u"
+    When "yellow" connects to the lobby "19yrzmetd2bn7" with the password "foobar"
+    Then "yellow" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
 
   Scenario: No password will not allow a player to join a lobby
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
         "password": "foobar"
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
-    When "yellow" tries to connect to the lobby "prb67ouj837u" without a password
+    When "yellow" tries to connect to the lobby "19yrzmetd2bn7" without a password
     Then "yellow" failed to join the lobby
     And the latest error for "yellow" is "invalid password"
 
 
   Scenario: A wrong password will not allow a player to join a lobby
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
         "password": "foobar"
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
-    When "yellow" tries to connect to the lobby "prb67ouj837u" with the password "wrong"
+    When "yellow" tries to connect to the lobby "19yrzmetd2bn7" with the password "wrong"
     Then "yellow" failed to join the lobby
     And the latest error for "yellow" is "invalid password"
 
 
   Scenario: You can change the password
-    Given "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "yellow" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "yellow" creates a lobby with these settings:
       """json
       {
@@ -60,16 +60,15 @@ Feature: Lobbies can be password protected
         "password": "foobar"
       }
       """
-    And "yellow" receives the network event "lobby" with the argument "19yrzmetd2bn7"
+    And "yellow" receives the network event "lobby" with the argument "h5yzwyizlwao"
 
     When "yellow" requests lobbies with this filter:
       """json
-      {
-      }
+      {}
       """
     Then "yellow" should have received only these lobbies:
-      | code          | hasPassword |
-      | 19yrzmetd2bn7 | true        |
+      | code         | hasPassword |
+      | h5yzwyizlwao | true        |
 
     When "yellow" updates the lobby with these settings:
       """json
@@ -79,24 +78,23 @@ Feature: Lobbies can be password protected
       """
     And "yellow" requests lobbies with this filter:
       """json
-      {
-      }
+      {}
       """
     Then "yellow" should have received only these lobbies:
-      | code          | hasPassword |
-      | 19yrzmetd2bn7 | false       |
+      | code         | hasPassword |
+      | h5yzwyizlwao | false       |
 
 
   Scenario: Players can add a password to a lobby and join it
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue" creates a lobby with these settings:
       """json
       {
         "password": ""
       }
       """
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
     When "blue" updates the lobby with these settings:
       """json
@@ -104,5 +102,5 @@ Feature: Lobbies can be password protected
         "password": "blabla"
       }
       """
-    And "yellow" connects to the lobby "prb67ouj837u" with the password "blabla"
-    Then "yellow" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "yellow" connects to the lobby "19yrzmetd2bn7" with the password "blabla"
+    Then "yellow" receives the network event "lobby" with the argument "19yrzmetd2bn7"

--- a/features/reconnect.feature
+++ b/features/reconnect.feature
@@ -8,47 +8,47 @@ Feature: Players can create and connect a network of players
   Scenario: Connections are reconnected before rtc is disconnected
     Given webrtc is intercepted by the testproxy
 
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
-    When "yellow" connects to the lobby "prb67ouj837u"
-    And "blue" receives the network event "connected" with the argument "[Peer: 3t3cfgcqup9e]"
+    When "yellow" connects to the lobby "19yrzmetd2bn7"
+    And "blue" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
 
     When the connection between "yellow" and "blue" is interrupted
     And webrtc is no longer intercepted by the testproxy
 
     And "blue" boardcasts "Hello, world!" over the reliable channel
-    And "yellow" receives the network event "message" with the arguments "[Peer: h5yzwyizlwao]", "reliable" and "Hello, world!"
+    And "yellow" receives the network event "message" with the arguments "[Peer: 1u8fw4aph5ypt]", "reliable" and "Hello, world!"
     And "yellow" has not seen the "reconnecting" event
 
 
   Scenario: Connections are reconnected when rtc is disconnected
     Given webrtc is intercepted by the testproxy
 
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
 
     When "blue" creates a lobby
-    And "blue" receives the network event "lobby" with the argument "prb67ouj837u"
+    And "blue" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
-    When "yellow" connects to the lobby "prb67ouj837u"
-    And "blue" receives the network event "connected" with the argument "[Peer: 3t3cfgcqup9e]"
+    When "yellow" connects to the lobby "19yrzmetd2bn7"
+    And "blue" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
 
     When the connection between "yellow" and "blue" is interrupted until the first "disconnected" state
 
-    Then "yellow" receives the network event "reconnecting" with the argument "[Peer: h5yzwyizlwao]"
-    And "yellow" receives the network event "reconnected" with the argument "[Peer: h5yzwyizlwao]"
+    Then "yellow" receives the network event "reconnecting" with the argument "[Peer: 1u8fw4aph5ypt]"
+    And "yellow" receives the network event "reconnected" with the argument "[Peer: 1u8fw4aph5ypt]"
     And "blue" boardcasts "Goodbye, world!" over the reliable channel
-    And "yellow" receives the network event "message" with the arguments "[Peer: h5yzwyizlwao]", "reliable" and "Goodbye, world!"
+    And "yellow" receives the network event "message" with the arguments "[Peer: 1u8fw4aph5ypt]", "reliable" and "Goodbye, world!"
 
 
   Scenario: A player reconnects when a websocket has been disconnected
     When "green" creates a network for game "de352868-ee35-474c-b703-510a37f911b2"
     Then "green" receives the network event "ready"
-    And "green" has recieved the peer ID "h5yzwyizlwao"
+    And "green" has recieved the peer ID "1u8fw4aph5ypt"
 
     When "green" disconnected from the signaling server
     Then "green" receives the network event "signalingerror" with the argument "[socket-error: signaling socket closed]"
@@ -58,40 +58,40 @@ Feature: Players can create and connect a network of players
   Scenario: Two player get disconnected
     Given webrtc is intercepted by the testproxy
 
-    Given "blue" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
-    And "yellow" is connected as "3t3cfgcqup9e" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    Given "blue" is connected as "1u8fw4aph5ypt" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
+    And "yellow" is connected as "h5yzwyizlwao" and ready for game "4307bd86-e1df-41b8-b9df-e22afcf084bd"
     And "blue,yellow" are joined in a lobby
 
     When the connection between "yellow" and "blue" is interrupted
 
-    Then "yellow" receives the network event "reconnecting" with the argument "[Peer: h5yzwyizlwao]"
-    And "yellow" receives the network event "disconnected" with the argument "[Peer: h5yzwyizlwao]"
-    And "blue" receives the network event "disconnected" with the argument "[Peer: 3t3cfgcqup9e]"
+    Then "yellow" receives the network event "reconnecting" with the argument "[Peer: 1u8fw4aph5ypt]"
+    And "yellow" receives the network event "disconnected" with the argument "[Peer: 1u8fw4aph5ypt]"
+    And "blue" receives the network event "disconnected" with the argument "[Peer: h5yzwyizlwao]"
 
 
   Scenario: Reconnect with the signaling server
     When "green" creates a network for game "302ce251-5d37-4274-ab44-31e1eb0c376a"
     Then "green" receives the network event "ready"
-    And "green" has recieved the peer ID "h5yzwyizlwao"
+    And "green" has recieved the peer ID "1u8fw4aph5ypt"
 
     When the websocket of "green" is reconnected
 
     Then "green" receives the network event "signalingreconnected"
-    And "green" has recieved the peer ID "h5yzwyizlwao"
+    And "green" has recieved the peer ID "1u8fw4aph5ypt"
 
 
   Scenario: Reconnect with the signaling server
-    Given "green" is connected as "h5yzwyizlwao" and ready for game "325a2754-1a6f-4578-b768-196463271229"
-    And "blue" is connected as "3t3cfgcqup9e" and ready for game "325a2754-1a6f-4578-b768-196463271229"
+    Given "green" is connected as "1u8fw4aph5ypt" and ready for game "325a2754-1a6f-4578-b768-196463271229"
+    And "blue" is connected as "h5yzwyizlwao" and ready for game "325a2754-1a6f-4578-b768-196463271229"
 
     When "green" creates a lobby
-    Then "green" receives the network event "lobby" with the argument "prb67ouj837u"
+    Then "green" receives the network event "lobby" with the argument "19yrzmetd2bn7"
 
     When the websocket of "green" is reconnected
     Then "green" receives the network event "signalingreconnected"
-    And "green" has recieved the peer ID "h5yzwyizlwao"
+    And "green" has recieved the peer ID "1u8fw4aph5ypt"
 
-    When "blue" connects to the lobby "prb67ouj837u"
-    Then "green" receives the network event "connected" with the argument "[Peer: 3t3cfgcqup9e]"
-    And "blue" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
+    When "blue" connects to the lobby "19yrzmetd2bn7"
+    Then "green" receives the network event "connected" with the argument "[Peer: h5yzwyizlwao]"
+    And "blue" receives the network event "connected" with the argument "[Peer: 1u8fw4aph5ypt]"
 

--- a/internal/util/identifiers.go
+++ b/internal/util/identifiers.go
@@ -15,9 +15,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// deterministicRand is used while running tests to ensure that the generated
+// identifiers are deterministic.
+// Each feature test will restart the signaling server, so running tests in a random
+// order will work as expected.
+var deterministicRand = rand.New(rand.NewSource(0))
+
 func GeneratePeerID(ctx context.Context) string {
 	if os.Getenv("ENV") == "test" {
-		return strconv.FormatInt(rand.Int63(), 36) // deterministic for testing
+		return strconv.FormatInt(deterministicRand.Int63(), 36) // deterministic for testing
 	}
 	return xid.New().String()
 }
@@ -37,11 +43,21 @@ func GenerateSecret(ctx context.Context) string {
 }
 
 func GenerateLobbyCode(ctx context.Context) string {
-	return strconv.FormatInt(rand.Int63(), 36)
+	randInt63 := rand.Int63
+	if os.Getenv("ENV") == "test" {
+		randInt63 = deterministicRand.Int63
+	}
+
+	return strconv.FormatInt(randInt63(), 36)
 }
 
 func GenerateShortLobbyCode(ctx context.Context) string {
+	randIntn := rand.Intn
+	if os.Getenv("ENV") == "test" {
+		randIntn = deterministicRand.Intn
+	}
+
 	numbers := []string{"2", "3", "4", "5", "6", "7", "8", "9"}
 	alphabet := []string{"A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "M", "N", "P", "R", "S", "T", "V", "W", "X", "Y", "Z"}
-	return numbers[rand.Intn(len(numbers))] + numbers[rand.Intn(len(numbers))] + alphabet[rand.Intn(len(alphabet))] + alphabet[rand.Intn(len(alphabet))]
+	return numbers[randIntn(len(numbers))] + numbers[randIntn(len(numbers))] + alphabet[randIntn(len(alphabet))] + alphabet[randIntn(len(alphabet))]
 }

--- a/lib/latency.ts
+++ b/lib/latency.ts
@@ -63,6 +63,6 @@ export default class Latency {
       this.jitter = this.window.slice(1).map((x, i) => Math.abs(x - this.window[i])).reduce((a, b) => a + b, 0) / (this.window.length - 1)
     }
 
-    setTimeout(() => this.ping(), PingInterval - delta)
+    setTimeout(() => this.ping(), Math.max(PingInterval - delta, 0))
   }
 }


### PR DESCRIPTION
Tests were using identifiers generated with a globally seeded `rand.Intn` etc. Working on some changes I found out that `pgx` also uses the global rand internally. Adding an extra query somewhere would make some tests have different identifiers all of a sudden.

Use a local statically seeded random number generator for tests so identifiers really always are the same.