### PR TITLE
Cucumber steps calling async functions should await them

### DIFF
--- a/features/support/steps/network.ts
+++ b/features/support/steps/network.ts
@@ -127,37 +127,37 @@ When('{string} creates a network for game {string}', async function (this: World
   await this.createPlayer(playerName, gameID)
 })
 
-When('{string} creates a lobby', function (this: World, playerName: string) {
+When('{string} creates a lobby', async function (this: World, playerName: string) {
   const player = this.players.get(playerName)
   if (player == null) {
     throw new Error('no such player')
   }
-  void player.network.create()
+  await player.network.create()
 })
 
-When('{string} creates a lobby with these settings:', function (this: World, playerName: string, settingsBlob: string) {
+When('{string} creates a lobby with these settings:', async function (this: World, playerName: string, settingsBlob: string) {
   const player = this.players.get(playerName)
   if (player == null) {
     throw new Error('no such player')
   }
   const settings = JSON.parse(settingsBlob)
-  void player.network.create(settings)
+  await player.network.create(settings)
 })
 
-When('{string} connects to the lobby {string}', function (this: World, playerName: string, lobbyCode: string) {
+When('{string} connects to the lobby {string}', async function (this: World, playerName: string, lobbyCode: string) {
   const player = this.players.get(playerName)
   if (player == null) {
     throw new Error('no such player')
   }
-  void player.network.join(lobbyCode)
+  await player.network.join(lobbyCode)
 })
 
-When('{string} connects to the lobby {string} with the password {string}', function (this: World, playerName: string, lobbyCode: string, password: string) {
+When('{string} connects to the lobby {string} with the password {string}', async function (this: World, playerName: string, lobbyCode: string, password: string) {
   const player = this.players.get(playerName)
   if (player == null) {
     throw new Error('no such player')
   }
-  void player.network.join(lobbyCode, password)
+  await player.network.join(lobbyCode, password)
 })
 
 When('{string} tries to connect to the lobby {string} with the password {string}', async function (this: World, playerName: string, lobbyCode: string, password: string) {


### PR DESCRIPTION
Otherwise you'll get an unclear UnhandledPromiseRejection instead of a proper error message.

For example when a `"peer" connects to the lobby` step is done with the wrong lobby you would get a:
```
UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "[object Object]".
    at throwUnhandledRejectionsMode (node:internal/process/promises:392:7)
    at processPromiseRejections (node:internal/process/promises:475:17)
    at processTicksAndRejections (node:internal/process/task_queues:106:32)
```
After this change you get:
```
SignalingError {
 type: 'server-error',
 message: 'lobby not found',
 event: undefined,
 code: 'lobby-not-found'
}
```