### PR TITLE
Remove peer MaxConnectionTime

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -17,8 +17,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const MaxConnectionTime = 1 * time.Hour
-
 const LobbyCleanInterval = 30 * time.Minute
 const LobbyCleanThreshold = 24 * time.Hour
 
@@ -50,9 +48,6 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 		ctx := r.Context()
 		logger := logging.GetLogger(ctx)
 		logger.Debug("upgrading connection")
-
-		ctx, cancel := context.WithTimeout(ctx, MaxConnectionTime)
-		defer cancel()
 
 		acceptOptions := &websocket.AcceptOptions{
 			InsecureSkipVerify: true, // Allow any origin/game to connect.

--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -49,6 +49,9 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 		logger := logging.GetLogger(ctx)
 		logger.Debug("upgrading connection")
 
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
 		acceptOptions := &websocket.AcceptOptions{
 			InsecureSkipVerify: true, // Allow any origin/game to connect.
 			CompressionMode:    websocket.CompressionDisabled,


### PR DESCRIPTION
There is no need to always disconnect the Websocket connection after an hour. This just causes issues once in a while with db queries being executed at the same time and then being cancelled.

**Edit:** it's actually causing issues quite often with`MarkPeerAsActive`. This function is scheduled every 30 seconds with a ticker. Because it's a ticker and keeps rhythm perfectly it is always running right after the hour and almost always causes a failed with `context deadline exceeded` error.