### PR TITLE
Ping the signaling server from the client

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -157,12 +157,16 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 				}
 				go metrics.RecordEvent(ctx, params)
 
-			case "pong":
+			case "ping", "pong":
 				// ignore, ping/pong is just for the tcp keepalive.
 
 			default:
 				if err := peer.HandlePacket(ctx, base.Type, raw); err != nil {
-					util.ErrorAndDisconnect(ctx, conn, err)
+					if err == ErrUnknownPacketType {
+						logger.Warn("unknown packet type received", zap.String("type", base.Type), zap.String("peer", peer.ID), zap.String("game", peer.Game), zap.String("origin", r.Header.Get("Origin")))
+					} else {
+						util.ErrorAndDisconnect(ctx, conn, err)
+					}
 				}
 			}
 		}

--- a/internal/signaling/peer.go
+++ b/internal/signaling/peer.go
@@ -17,6 +17,8 @@ import (
 
 const DefaultMaxPlayers = 4
 
+var ErrUnknownPacketType = fmt.Errorf("unknown packet type")
+
 type Peer struct {
 	store stores.Store
 	conn  *websocket.Conn
@@ -172,7 +174,7 @@ func (p *Peer) HandlePacket(ctx context.Context, typ string, raw []byte) error {
 		}
 
 	default:
-		logger.Warn("unknown packet type received", zap.String("type", typ))
+		return ErrUnknownPacketType
 	}
 
 	return nil

--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -33,6 +33,12 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
     this.replayQueue = new Map()
 
     this.ws = this.connect()
+
+    // Send a ping every 5 seconds to keep the connection alive,
+    // and to detect when the connection is lost.
+    setInterval(() => {
+      this.ping()
+    }, 5000)
   }
 
   private connect (): WebSocket {
@@ -137,6 +143,19 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
     if (this.ws.readyState === WebSocket.OPEN) {
       this.network.log('sending signaling packet:', packet.type)
       const data = JSON.stringify(packet)
+      this.ws.send(data)
+    }
+  }
+
+  ping (): void {
+    // Send a ping to the server to keep the connection alive,
+    // and to detect when the connection is lost.
+    // Sending is enough, we don't need to listen for a pong.
+    // Don't use this.send() as we don't need every ping to be logged.
+    if (this.ws.readyState === WebSocket.OPEN) {
+      const data = JSON.stringify({
+        type: 'ping'
+      })
       this.ws.send(data)
     }
   }


### PR DESCRIPTION
Send pings to be able to detect broken connections. No need for a pong, TCP will take care of that.

Log the origin with "unknown packet type received" so we can see which clients are sending packets the server doesn't support (in this case it was ping from old clients?).

Fixes https://github.com/poki/netlib/issues/183