### PR TITLE
Don't call MarkPeerAsActive when util.ShouldIgnoreNetworkError is true

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -88,11 +88,13 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 			for {
 				select {
 				case <-ticker.C:
-					if err := peer.Send(ctx, PingPacket{Type: "ping"}); err != nil && !util.ShouldIgnoreNetworkError(err) {
-						if strings.Contains(err.Error(), "write: broken pipe") {
-							logger.Warn("failed to send ping packet", zap.String("peer", peer.ID), zap.Error(err))
-						} else {
-							logger.Error("failed to send ping packet", zap.String("peer", peer.ID), zap.Error(err))
+					if err := peer.Send(ctx, PingPacket{Type: "ping"}); err != nil {
+						if !util.ShouldIgnoreNetworkError(err) {
+							if strings.Contains(err.Error(), "write: broken pipe") {
+								logger.Warn("failed to send ping packet", zap.String("peer", peer.ID), zap.Error(err))
+							} else {
+								logger.Error("failed to send ping packet", zap.String("peer", peer.ID), zap.Error(err))
+							}
 						}
 					} else {
 						// If we can send a ping packet, and the peer has an ID, we update the peer as being active.


### PR DESCRIPTION
These are network errors we just don't want to log. They will still cause the connection to be closed and the context to be cancelled causing MarkPeerAsActive to error with 'context canceled'.