### PR TITLE
Don't try to send a message on a closed websocket connection

### DIFF
--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -129,6 +129,7 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
     return await new Promise<SignalingPacketTypes>((resolve, reject) => {
       if (this.ws.readyState !== WebSocket.OPEN) {
         reject(new SignalingError('socket-error', 'signaling socket not open'))
+        return
       }
       const rid = Math.random().toString(36).slice(2)
       packet.rid = rid


### PR DESCRIPTION
If we don't return after the reject we would still try to send the message.

This issue was found by OpenAI o3.