### PR TITLE
Fix ping interval cleanup

### DIFF
--- a/lib/signaling.ts
+++ b/lib/signaling.ts
@@ -25,6 +25,8 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
 
   private readonly requests: Map<string, RequestHandler> = new Map()
 
+  private pingInterval?: ReturnType<typeof setInterval>
+
   constructor (private readonly network: Network, peers: Map<string, Peer>, url: string) {
     super()
 
@@ -36,7 +38,7 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
 
     // Send a ping every 5 seconds to keep the connection alive,
     // and to detect when the connection is lost.
-    setInterval(() => {
+    this.pingInterval = setInterval(() => {
       this.ping()
     }, 5000)
   }
@@ -122,6 +124,10 @@ export default class Signaling extends EventEmitter<SignalingListeners> {
   }
 
   close (): void {
+    if (this.pingInterval !== undefined) {
+      clearInterval(this.pingInterval)
+      this.pingInterval = undefined
+    }
     this.ws.close()
   }
 


### PR DESCRIPTION
## Summary
- track the ping setInterval in Signaling
- clear the ping interval on WebSocket close

## Testing
- `yarn lint`
- `yarn cucumber` *(fails: 37 scenarios failed)*

------
https://chatgpt.com/codex/tasks/task_e_686ccdde383483208ce0b4b68273afc2