### PR TITLE
Fix rtcerror typing

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -79,6 +79,7 @@ Subscribe to events using `network.on(eventName, callback)`:
 - `'error'`: Network error occurred
 - `'connected'`: New peer connected
 - `'disconnected'`: Peer disconnected
+- `'rtcerror'`: WebRTC error occurred (callback receives `RTCErrorEvent`)
 
 #### Lobby Events
 - `'lobby'`: Lobby created/joined

--- a/example/main.ts
+++ b/example/main.ts
@@ -101,7 +101,7 @@ n.on('lobby', code => {
 })
 
 n.on('signalingerror', console.error.bind(console.error))
-n.on('rtcerror', console.error.bind(console.error))
+n.on('rtcerror', (e: RTCErrorEvent) => console.error(e))
 
 n.on('connecting', peer => { log(`peer connecting ${peer.id}`) })
 n.on('disconnected', peer => {

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -20,7 +20,7 @@ interface NetworkListeners {
   failed: () => void | Promise<void>
   message: (peer: Peer, channel: string, data: string | Blob | ArrayBuffer | ArrayBufferView) => void | Promise<void>
   close: (reason?: string) => void | Promise<void>
-  rtcerror: (e: Event) => void | Promise<void> // TODO: Figure out how to make this e type be RTCErrorEvent
+  rtcerror: (e: RTCErrorEvent) => void | Promise<void>
   signalingerror: (e: SignalingError) => void | Promise<void>
 }
 

--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -216,7 +216,7 @@ export default class Peer {
     }
   }
 
-  private onError (e: Event): void {
+  private onError (e: RTCErrorEvent): void {
     this.network.emit('rtcerror', e)
     if (this.network.listenerCount('rtcerror') === 0) {
       console.error('rtcerror not handled:', e)


### PR DESCRIPTION
## Summary
- use `RTCErrorEvent` for the `rtcerror` listener
- update docs and example with RTCErrorEvent

## Testing
- `yarn lint`
- `npx tsc --noEmit`
- `yarn cucumber` *(fails: failed setup store)*

------
https://chatgpt.com/codex/tasks/task_e_686ccdf27f7c8320b3f92e0bf6372a6f