### PR TITLE
Default the signalling server to production

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import { PokiTurnMatch } from './credentials'
 import { PeerConfiguration } from './types'
 
-export const DefaultSignalingURL = process.env.NODE_ENV === 'production' ? 'wss://netlib.poki.io/v0/signaling' : 'ws://localhost:8080/v0/signaling'
+export const DefaultSignalingURL = process.env.NODE_ENV === 'test' ? 'ws://localhost:8080/v0/signaling' : 'wss://netlib.poki.io/v0/signaling'
 
 export const DefaultRTCConfiguration: PeerConfiguration = {
   iceServers: [


### PR DESCRIPTION
It's currently required to set `NODE_ENV=production` while building your app. This is very unintuitive. Default to using the production server instead of a local test server.

Fixes: https://github.com/poki/netlib/issues/250