### PR TITLE
Improve Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,21 @@ UDP Transport
 
 While Poki provides hosted STUN/TURN and signaling services for free, you can also self-host these components:
 
-1. Set up your own signaling server using the provided Docker image
-2. Configure your own STUN/TURN servers
-3. Initialize the network with custom endpoints:
+1. Set up your own signaling server
+
+    Using the provided Docker image:
+    ```sh
+    $ docker build -t netlib .
+    $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -p 8080:8080 -e ENV=local netlib
+    ```
+    Or by running the signaling server binary directly:
+    ```sh
+    $ go build -o signaling cmd/signaling/main.go
+    $ ENV=local ./signaling
+    ```
+2. For persistent storage remove `ENV=local` and set `DATABASE_URL` to your PostgreSQL database URL.
+3. Configure your own STUN/TURN servers.
+4. Initialize the network with custom endpoints:
 ```js
 const network = new Network('<game-id>', {
   signalingServer: 'wss://your-server.com',

--- a/cmd/signaling/main.go
+++ b/cmd/signaling/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/poki/netlib/internal/util"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -32,7 +33,9 @@ func main() {
 
 	store, flushed, err := stores.FromEnv(ctx)
 	if err != nil {
-		logger.Panic("failed setup store", zap.Error(err))
+		// Don't print a stacktrace here, it's confusing for users.
+		logger.WithOptions(zap.AddStacktrace(zapcore.InvalidLevel)).Error("failed to setup store", zap.Error(err))
+		return
 	}
 
 	if os.Getenv("ENV") == "local" || os.Getenv("ENV") == "test" {

--- a/internal/signaling/stores/postgres.go
+++ b/internal/signaling/stores/postgres.go
@@ -624,10 +624,7 @@ func (s *PostgresStore) DoLeaderElection(ctx context.Context, gameID, lobbyCode 
 		return nil, err
 	}
 
-	needNewLeader := false
-	if currentLeader == "" {
-		needNewLeader = true
-	}
+	needNewLeader := currentLeader == ""
 
 	if !needNewLeader {
 		found := slices.Contains(peers, currentLeader)


### PR DESCRIPTION
- Add better explanation on how to run the signaling server yourself.
- Improve temporary postgres setup.

Also cleanup the error when the store can't be setup. Otherwise you get this confusing broken stacktrace:
```
% docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -p 8080:8080 netlib 
2025-07-22T09:52:33.883Z	INFO	signaling/main.go:29	init	{"env": "local", "service": "netlib", "component": "signaling"}
2025-07-22T09:52:33.990Z	INFO	stores/setup.go:77	using database	{"env": "local", "service": "netlib", "component": "signaling", "url": "postgres://test:test@localhost:33225/test?sslmode=disable"}
2025-07-22T09:54:32.873Z	PANIC	signaling/main.go:35	failed setup store	{"env": "local", "service": "netlib", "component": "signaling", "error": "reached retry deadline: failed to connect to `user=test database=test`:\n\t127.0.0.1:33225 (localhost): dial error: dial tcp 127.0.0.1:33225: connect: connection refused\n\t[::1]:33225 (localhost): dial error: dial tcp [::1]:33225: connect: connection refused"}
main.main
	/netlib/cmd/signaling/main.go:35
runtime.main
	/usr/local/go/src/runtime/proc.go:283
2025-07-22T09:54:32.873Z	INFO	runtime/panic.go:792	fin	{"env": "local", "service": "netlib", "component": "signaling"}
panic: failed setup store

goroutine 1 [running]:
go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x0?, 0x1?, {0x1?, 0x0?, 0x0?})
	/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:196 +0x78
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0x4000095c70, {0x4000346400, 0x1, 0x1})
	/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:262 +0x1b8
go.uber.org/zap.(*Logger).Panic(0x78cdf8?, {0x6aaef5?, 0x6a3c70?}, {0x4000346400, 0x1, 0x1})
	/go/pkg/mod/go.uber.org/zap@v1.27.0/logger.go:285 +0x4c
main.main()
	/netlib/cmd/signaling/main.go:35 +0x220
```