### PR TITLE
Delay dependabot updates by 5 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -16,6 +18,8 @@ updates:
       gomod:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -24,6 +28,8 @@ updates:
       docker:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -32,3 +38,5 @@ updates:
       npm:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5


### PR DESCRIPTION
Wait 5 days to get updates. We hope supply chain attacks are detected before these 5 days.