### PR TITLE
Emit more avg-latency-at- events

### DIFF
--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -23,7 +23,7 @@ const LobbyCleanThreshold = 24 * time.Hour
 const peerPingDuration = 2 * time.Second
 const peerActiveUpdateInterval = 30 * time.Second
 
-// Countries to track states/regions for the avg-latency-at-10s event.
+// Countries to track states/regions for the avg-latency-at-Xs events.
 // United States
 // Canada
 // Australia
@@ -197,9 +197,9 @@ func Handler(ctx context.Context, store stores.Store, cloudflare *cloudflare.Cre
 					util.ErrorAndDisconnect(reqCtx, conn, err)
 				}
 
-				// Add country and region to event data of the avg-latency-at-10s event.
+				// Add country and region to event data of the avg-latency-at-Xs events.
 				// We want to use this data to build a latency world map.
-				if params.Action == "avg-latency-at-10s" && params.Data != nil && peer != nil {
+				if strings.HasPrefix(params.Action, "avg-latency-at-") && strings.HasSuffix(params.Action, "s") && params.Data != nil && peer != nil {
 					params.Data["country"] = peer.Country
 
 					// For big countries, also track the region/state so we can try and use this to

--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -5,6 +5,7 @@ import { PeerConfiguration, SignalingPacketTypes } from './types'
 
 const LatencyRestartIceThreshold = 1000 // ms
 const ReconnectionWindow = 8000 // ms
+const LatencyReportIntervals = [10, 25, 50, 75, 100] as const
 
 export default class Peer {
   public readonly conn: RTCPeerConnection
@@ -25,7 +26,7 @@ export default class Peer {
   private lastMessageReceivedAt: number = 0
 
   private politenessTimeout?: ReturnType<typeof setTimeout>
-  private reportLatencyEventTimeout?: ReturnType<typeof setTimeout>
+  private readonly reportLatencyEventTimeouts: Array<ReturnType<typeof setTimeout>> = []
   private readonly checkStateInterval: ReturnType<typeof setInterval>
   private readonly channels: { [name: string]: RTCDataChannel }
 
@@ -128,9 +129,11 @@ export default class Peer {
           this.opened = true
           this.network.emit('connected', this)
           void this.signaling.event('rtc', 'connected', { target: this.id })
-          this.reportLatencyEventTimeout = setTimeout(() => {
-            void this.signaling.event('rtc', 'avg-latency-at-10s', { target: this.id, latency: `${this.latency.average}` })
-          }, 10000)
+          for (const seconds of LatencyReportIntervals) {
+            this.reportLatencyEventTimeouts.push(setTimeout(() => {
+              void this.signaling.event('rtc', `avg-latency-at-${seconds}s`, { target: this.id, latency: `${this.latency.average}` })
+            }, seconds * 1000))
+          }
         }
       })
       chan.addEventListener('message', e => {
@@ -162,9 +165,10 @@ export default class Peer {
     if (this.checkStateInterval != null) {
       clearInterval(this.checkStateInterval)
     }
-    if (this.reportLatencyEventTimeout != null) {
-      clearTimeout(this.reportLatencyEventTimeout)
+    for (const reportLatencyEventTimeout of this.reportLatencyEventTimeouts) {
+      clearTimeout(reportLatencyEventTimeout)
     }
+    this.reportLatencyEventTimeouts.length = 0
 
     if (this.opened) {
       this.network.emit('disconnected', this)


### PR DESCRIPTION
We want to get more information on how the latency behaves over time.
This PR adds more avg-latency-at events.