### PR TITLE
Upgrade Go to 1.26.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.0'
+        go-version: '1.26.5'
     - run: yarn install --frozen-lockfile
     - run: yarn lint
     - run: yarn cucumber
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v6
       with:
-        go-version: 1.26
+        go-version: 1.26.5
     - uses: actions/checkout@v7
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 WORKDIR /netlib
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/poki/netlib
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/coder/websocket v1.8.15


### PR DESCRIPTION
Updates Go to 1.26.5 and keeps CI and Docker pins aligned.

Validated with go test ./...